### PR TITLE
feat: Extend the solver

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,13 +10,9 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
-  jobs:
-    pre_build:
-      - pip install --no-deps .
-      # Can add other checks in here if things blow up confusingly
-    post_install:
-      - uv list
-
-mkdocs:
-  configuration: mkdocs.yml
-  fail_on_warning: true
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv sync --frozen
+    - NO_COLOR=1 uv run mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 <!--- sec-begin-description -->
 
+Status: This project is in active development. We expect to be ready for beta releases in Q2 2025.
+
 The CMIP Rapid Evaluation Framework is a Python application that provides the ability to rapidly process and
 evaluate CMIP data against a set of reference data.
 It is designed to be used as a CI/CD pipeline to provide a quick validation of CMIP data.
@@ -37,6 +39,8 @@ don't render correctly on GitHub's viewer.
 <!--- sec-begin-installation -->
 
 CMIP Rapid Evaluation Framework can be installed with pip, mamba or conda:
+
+The following commands don't work yet, but will be updated when we have a release.
 
 ```bash
 pip install cmip-ref

--- a/changelog/16.docs.md
+++ b/changelog/16.docs.md
@@ -1,0 +1,1 @@
+Deployed documentation to https://cmip-ref.readthedocs.io/en/latest/

--- a/changelog/16.feature.md
+++ b/changelog/16.feature.md
@@ -1,0 +1,1 @@
+Add a placeholder iterative metric solving scheme

--- a/conftest.py
+++ b/conftest.py
@@ -4,12 +4,10 @@ Re-useable fixtures etc. for tests that are shared across the whole project
 See https://docs.pytest.org/en/7.1.x/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files
 """
 
-import logging
 from pathlib import Path
 
 import esgpull
 import pytest
-from loguru import logger
 
 
 @pytest.fixture
@@ -17,14 +15,3 @@ def esgf_data_dir() -> Path:
     pull = esgpull.Esgpull()
 
     return pull.config.paths.data
-
-
-@pytest.fixture
-def caplog(_caplog):
-    class PropogateHandler(logging.Handler):
-        def emit(self, record):
-            logging.getLogger(record.name).handle(record)
-
-    handler_id = logger.add(PropogateHandler(), format="{message}")
-    yield _caplog
-    logger.remove(handler_id)

--- a/conftest.py
+++ b/conftest.py
@@ -4,10 +4,12 @@ Re-useable fixtures etc. for tests that are shared across the whole project
 See https://docs.pytest.org/en/7.1.x/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files
 """
 
+import logging
 from pathlib import Path
 
 import esgpull
 import pytest
+from loguru import logger
 
 
 @pytest.fixture
@@ -15,3 +17,14 @@ def esgf_data_dir() -> Path:
     pull = esgpull.Esgpull()
 
     return pull.config.paths.data
+
+
+@pytest.fixture
+def caplog(_caplog):
+    class PropogateHandler(logging.Handler):
+        def emit(self, record):
+            logging.getLogger(record.name).handle(record)
+
+    handler_id = logger.add(PropogateHandler(), format="{message}")
+    yield _caplog
+    logger.remove(handler_id)

--- a/packages/ref-core/src/ref_core/exceptions.py
+++ b/packages/ref-core/src/ref_core/exceptions.py
@@ -7,6 +7,15 @@ class RefException(Exception):
     pass
 
 
+class InvalidMetricException(RefException):
+    """Exception raised when an invalid metric is registered"""
+
+    def __init__(self, metric) -> None:
+        message = f"Invalid metric: '{metric}'\n" "Metrics must be an instance of the 'Metric' class"
+
+        super().__init__(message)
+
+
 class OutOfTreeDatasetException(RefException):
     """Exception raised when a dataset is not in the datatree"""
 

--- a/packages/ref-core/src/ref_core/exceptions.py
+++ b/packages/ref-core/src/ref_core/exceptions.py
@@ -1,4 +1,5 @@
 import pathlib
+from typing import Any
 
 
 class RefException(Exception):
@@ -10,7 +11,7 @@ class RefException(Exception):
 class InvalidMetricException(RefException):
     """Exception raised when an invalid metric is registered"""
 
-    def __init__(self, metric) -> None:
+    def __init__(self, metric: Any) -> None:
         message = f"Invalid metric: '{metric}'\n" "Metrics must be an instance of the 'Metric' class"
 
         super().__init__(message)

--- a/packages/ref-core/src/ref_core/providers.py
+++ b/packages/ref-core/src/ref_core/providers.py
@@ -4,6 +4,8 @@ Interfaces for metrics providers.
 This defines how metrics packages interoperate with the REF framework.
 """
 
+from collections.abc import Iterator
+
 from ref_core.exceptions import InvalidMetricException
 from ref_core.metrics import Metric
 
@@ -21,16 +23,16 @@ class MetricsProvider:
 
         self._metrics: dict[str, Metric] = {}
 
-    def metrics(self) -> list[Metric]:
+    def metrics(self) -> Iterator[Metric]:
         """
-        Get the names of all registered metrics.
+        Iterate over the available metrics for the provider.
 
         Returns
         -------
         :
-            Names of all registered metrics.
+            Iterator over the currently registered metrics.
         """
-        return list(self._metrics.values())
+        return iter(self._metrics.values())
 
     def __len__(self) -> int:
         return len(self._metrics)

--- a/packages/ref-core/src/ref_core/providers.py
+++ b/packages/ref-core/src/ref_core/providers.py
@@ -4,6 +4,7 @@ Interfaces for metrics providers.
 This defines how metrics packages interoperate with the REF framework.
 """
 
+from ref_core.exceptions import InvalidMetricException
 from ref_core.metrics import Metric
 
 
@@ -20,6 +21,17 @@ class MetricsProvider:
 
         self._metrics: dict[str, Metric] = {}
 
+    def metrics(self) -> list[Metric]:
+        """
+        Get the names of all registered metrics.
+
+        Returns
+        -------
+        :
+            Names of all registered metrics.
+        """
+        return list(self._metrics.values())
+
     def __len__(self) -> int:
         return len(self._metrics)
 
@@ -33,7 +45,7 @@ class MetricsProvider:
             The metric to register.
         """
         if not isinstance(metric, Metric):
-            raise ValueError("Metric must be an instance of Metric")
+            raise InvalidMetricException(metric)
         self._metrics[metric.name.lower()] = metric
 
     def get(self, name: str) -> Metric:

--- a/packages/ref-core/src/ref_core/providers.py
+++ b/packages/ref-core/src/ref_core/providers.py
@@ -4,8 +4,6 @@ Interfaces for metrics providers.
 This defines how metrics packages interoperate with the REF framework.
 """
 
-from collections.abc import Iterator
-
 from ref_core.exceptions import InvalidMetricException
 from ref_core.metrics import Metric
 
@@ -23,7 +21,7 @@ class MetricsProvider:
 
         self._metrics: dict[str, Metric] = {}
 
-    def metrics(self) -> Iterator[Metric]:
+    def metrics(self) -> list[Metric]:
         """
         Iterate over the available metrics for the provider.
 
@@ -32,7 +30,7 @@ class MetricsProvider:
         :
             Iterator over the currently registered metrics.
         """
-        return iter(self._metrics.values())
+        return list(self._metrics.values())
 
     def __len__(self) -> int:
         return len(self._metrics)

--- a/packages/ref-core/tests/unit/test_providers.py
+++ b/packages/ref-core/tests/unit/test_providers.py
@@ -1,3 +1,5 @@
+import pytest
+from ref_core.exceptions import InvalidMetricException
 from ref_core.metrics import Metric
 from ref_core.providers import MetricsProvider
 
@@ -17,6 +19,17 @@ class TestMetricsProvider:
         assert len(provider) == 1
         assert "mock" in provider._metrics
         assert isinstance(provider.get("mock"), Metric)
+
+        assert len(provider.metrics()) == 1
+        assert provider.metrics()[0].name == "mock"
+
+    def test_provider_register_invalid(self):
+        class InvalidMetric:
+            pass
+
+        provider = MetricsProvider("provider_name", "v0.23")
+        with pytest.raises(InvalidMetricException):
+            provider.register(InvalidMetric())
 
     def test_provider_fixture(self, provider):
         assert provider.name == "mock_provider"

--- a/packages/ref/src/ref/cli/__init__.py
+++ b/packages/ref/src/ref/cli/__init__.py
@@ -18,7 +18,7 @@ class _InterceptHandler(logging.Handler):
         level: str | int
         try:
             level = logger.level(record.levelname).name
-        except ValueError:
+        except ValueError:  # pragma: no cover
             level = record.levelno
 
         # Find caller from where originated the logged message.

--- a/packages/ref/src/ref/cli/solve.py
+++ b/packages/ref/src/ref/cli/solve.py
@@ -27,11 +27,4 @@ def solve(
     solver = MetricSolver.build_from_db(db)
 
     logger.info("Solving for metrics that require recalculation...")
-    metric_runs = solver.solve()
-
-    logger.info(f"Found {len(metric_runs)} new calculations to be made")
-
-    if not dry_run:
-        logger.info(f"Found {len(metric_runs)} new calculations to be made")
-        for metric_run in metric_runs:
-            logger.info(f"Registering metric run: {metric_run}")
+    solver.solve(dry_run=dry_run)

--- a/packages/ref/src/ref/provider_registry.py
+++ b/packages/ref/src/ref/provider_registry.py
@@ -1,0 +1,34 @@
+from attrs import field, frozen
+from ref_core.providers import MetricsProvider
+
+from ref.database import Database
+
+
+@frozen
+class ProviderRegistry:
+    """
+    Registry for the currently active providers
+
+    In some cases we can't directly import a provider and it's metrics,
+    in this case we need to proxy the metrics.
+    """
+
+    providers: list[MetricsProvider] = field(factory=list)
+
+    @staticmethod
+    def build_from_db(db: Database) -> "ProviderRegistry":
+        """
+        Create a ProviderRegistry instance using information from the database
+
+        Parameters
+        ----------
+        db
+            Database instance
+
+        Returns
+        -------
+        :
+            A new ProviderRegistry instance
+        """
+        # TODO: We don't yet have any tables to represent metrics providers
+        return ProviderRegistry(providers=[])

--- a/packages/ref/src/ref/solver.py
+++ b/packages/ref/src/ref/solver.py
@@ -2,20 +2,28 @@ import typing
 
 import pandas as pd
 from attrs import define
+from loguru import logger
+from ref_core.datasets import SourceDatasetType
+from ref_core.metrics import Metric
+from ref_core.providers import MetricsProvider
 
 from ref.database import Database
+from ref.provider_registry import ProviderRegistry
 
 
 @define
 class MetricSolver:
     """
-    A class that can solve which metrics need to be calculated
+    A solver to determine which metrics need to be calculated
     """
+
+    provider_registry: ProviderRegistry
+    data_catalog: dict[SourceDatasetType, pd.DataFrame]
 
     @staticmethod
     def build_from_db(db: Database) -> "MetricSolver":
         """
-        Create a MetricSolver instance using information from the database
+        Initialise the solver using information from the database
 
         Parameters
         ----------
@@ -27,39 +35,63 @@ class MetricSolver:
         :
             A new MetricSolver instance
         """
-        return MetricSolver()
+        return MetricSolver(provider_registry=ProviderRegistry.build_from_db(db), data_catalog={})
 
-    @staticmethod
-    def build_from_dataframe(dataframe: pd.DataFrame) -> "MetricSolver":
+    def _can_solve(self, metric: Metric) -> bool:
         """
-        Create a MetricSolver instance using information from a data catalog.
+        Determine if a metric can be solved
 
-        This is useful in the cases where a database is not available or for testing.
+        This should probably be passed via DI
+        """
+        return True
 
-        Parameters
-        ----------
-        db
-            Database instance
+    def _find_solvable(self) -> typing.Generator[tuple[MetricsProvider, Metric], None, None]:
+        """
+        Find metrics that can be solved
 
         Returns
         -------
         :
-            A new MetricSolver instance
+            List of metrics that can be solved
         """
-        return MetricSolver()
+        for provider in self.provider_registry.providers:
+            for metric in provider.metrics():
+                if self._can_solve(metric):
+                    yield provider, metric
 
-    def solve(self) -> list[typing.Any]:
+    def solve(self, dry_run: bool = False, max_iterations: int = 10) -> None:
         """
         Solve which metrics need to be calculated for a dataset
 
+        The solving scheme is iterative,
+        for each iteration we find all metrics that can be solved and calculate them.
+        After each iteration we check if there are any more metrics to solve.
+        This may not be the most efficient way to solve the metrics, but it's a start.
+
         Parameters
         ----------
-        dataset
-            Dataset to calculate metrics for
-
-        Returns
-        -------
-        :
-            List of metrics that need to be calculated
+        dry_run
+            If true, don't actually calculate the metrics instead just log what would be calculated
+        max_iterations
+            The maximum number of solving iterations to run
         """
-        return []
+        if dry_run:
+            max_iterations = 1
+
+        # Solve iteratively for now
+        for iteration in range(max_iterations):
+            logger.debug(f"Iteration {iteration}")
+            solve_count = 0
+
+            for provider, metric in self._find_solvable():
+                logger.info(f"Calculating {metric}")
+
+                if not dry_run:
+                    pass
+                    # run_metric(provider, metric, data_catalog=self.data_catalog)
+                solve_count += 1
+
+            logger.info(f"{solve_count} metrics calculated in iteration: {iteration}")
+            if solve_count == 0:
+                logger.info("No more metrics to solve")
+                break

--- a/packages/ref/tests/unit/cli/test_root.py
+++ b/packages/ref/tests/unit/cli/test_root.py
@@ -1,0 +1,35 @@
+from typer.testing import CliRunner
+
+from ref import __core_version__, __version__
+from ref.cli import app
+
+runner = CliRunner(mix_stderr=False)
+
+
+def test_without_subcommand():
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "Usage: ref" in result.output
+    assert "ref: A CLI for the CMIP Rapid Evaluation Framework" in result.output
+
+
+def test_version():
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert f"ref: {__version__}\nref-core: {__core_version__}" in result.output
+
+
+def test_verbose():
+    exp_log = "| DEBUG    | ref.config:default:176 - Loading default configuration from"
+    result = runner.invoke(
+        app,
+        ["--verbose", "config", "list"],
+    )
+    assert exp_log in result.stderr
+
+    result = runner.invoke(
+        app,
+        ["config", "list"],
+    )
+    # Only info and higher messages logged
+    assert exp_log not in result.stderr

--- a/packages/ref/tests/unit/cli/test_root.py
+++ b/packages/ref/tests/unit/cli/test_root.py
@@ -3,14 +3,16 @@ from typer.testing import CliRunner
 from ref import __core_version__, __version__
 from ref.cli import app
 
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner(
+    mix_stderr=False,
+)
 
 
 def test_without_subcommand():
     result = runner.invoke(app, [])
     assert result.exit_code == 0
-    assert "Usage: ref" in result.output
-    assert "ref: A CLI for the CMIP Rapid Evaluation Framework" in result.output
+    assert "Usage: ref" in result.stdout
+    assert "ref: A CLI for the CMIP Rapid Evaluation Framework" in result.stdout
 
 
 def test_version():

--- a/packages/ref/tests/unit/cli/test_root.py
+++ b/packages/ref/tests/unit/cli/test_root.py
@@ -11,7 +11,8 @@ runner = CliRunner(
 def test_without_subcommand():
     result = runner.invoke(app, [])
     assert result.exit_code == 0
-    assert "Usage: ref" in result.stdout
+    assert "Usage:" in result.stdout
+    assert "ref [OPTIONS] COMMAND [ARGS]" in result.stdout
     assert "ref: A CLI for the CMIP Rapid Evaluation Framework" in result.stdout
 
 

--- a/packages/ref/tests/unit/test_solver.py
+++ b/packages/ref/tests/unit/test_solver.py
@@ -1,0 +1,20 @@
+from ref.provider_registry import ProviderRegistry
+from ref.solver import MetricSolver
+
+
+def test_solver_build_from_db(db):
+    solver = MetricSolver.build_from_db(db)
+
+    assert isinstance(solver, MetricSolver)
+    assert isinstance(solver.provider_registry, ProviderRegistry)
+    assert solver.data_catalog == {}
+
+
+def test_solver_solve_empty(db):
+    solver = MetricSolver.build_from_db(db)
+    solver.solve()
+
+
+def test_solver_solve_with_datasets(db):
+    solver = MetricSolver.build_from_db(db)
+    solver.solve()

--- a/packages/ref/tests/unit/test_solver.py
+++ b/packages/ref/tests/unit/test_solver.py
@@ -1,20 +1,22 @@
+import pytest
+
 from ref.provider_registry import ProviderRegistry
 from ref.solver import MetricSolver
 
 
-def test_solver_build_from_db(db):
-    solver = MetricSolver.build_from_db(db)
-
-    assert isinstance(solver, MetricSolver)
-    assert isinstance(solver.provider_registry, ProviderRegistry)
-    assert solver.data_catalog == {}
+@pytest.fixture
+def solver(db) -> MetricSolver:
+    return MetricSolver.build_from_db(db)
 
 
-def test_solver_solve_empty(db):
-    solver = MetricSolver.build_from_db(db)
-    solver.solve()
+class TestMetricSolver:
+    def test_solver_build_from_db(self, solver):
+        assert isinstance(solver, MetricSolver)
+        assert isinstance(solver.provider_registry, ProviderRegistry)
+        assert solver.data_catalog == {}
 
+    def test_solver_solve_empty(self, solver):
+        solver.solve()
 
-def test_solver_solve_with_datasets(db):
-    solver = MetricSolver.build_from_db(db)
-    solver.solve()
+    def test_solver_solve_with_datasets(self, solver):
+        solver.solve()

--- a/packages/ref/tests/unit/test_solver.py
+++ b/packages/ref/tests/unit/test_solver.py
@@ -15,8 +15,12 @@ class TestMetricSolver:
         assert isinstance(solver.provider_registry, ProviderRegistry)
         assert solver.data_catalog == {}
 
+    def test_solver_dry_run(self, solver):
+        solver.solve(dry_run=True)
+
+        # TODO: Check that nothing was solved
+
     def test_solver_solve_empty(self, solver):
         solver.solve()
 
-    def test_solver_solve_with_datasets(self, solver):
-        solver.solve()
+        # TODO: Check that nothing was solved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev-dependencies = [
     "jupytext>=1.16.3",
     "esgpull>=0.7.3",
     "pandas-stubs>=2.2.3.241009",
+    "pytest-loguru>=0.4.0",
 ]
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -496,6 +496,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-loguru" },
     { name = "ruff" },
     { name = "towncrier" },
 ]
@@ -528,6 +529,7 @@ dev = [
     { name = "pre-commit", specifier = ">=3.3.1" },
     { name = "pytest", specifier = ">=7.3.1" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-loguru", specifier = ">=0.4.0" },
     { name = "ruff", specifier = ">=0.6.9" },
     { name = "towncrier", specifier = ">=24.8.0" },
 ]
@@ -2827,6 +2829,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/67/00efc8d11b630c56f15f4ad9c7f9223f1e5ec275aaae3fa9118c6a223ad2/pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857", size = 63042 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/3a/af5b4fa5961d9a1e6237b530eb87dd04aea6eb83da09d2a4073d81b54ccf/pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652", size = 21990 },
+]
+
+[[package]]
+name = "pytest-loguru"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "loguru" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/f2/8ca6c8780e714fbfd35d7dcc772af99310272a01457b0887c90c75f2ec52/pytest_loguru-0.4.0.tar.gz", hash = "sha256:0d9e4e72ae9bfd92f774c666e7353766af11b0b78edd59c290e89be116050f03", size = 6696 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/ef/b0c2e96e3508bca8d1874e39789d541cd7f4731b38bcf9c7098f0b882001/pytest_loguru-0.4.0-py3-none-any.whl", hash = "sha256:3cc7b9c6b22cb158209ccbabf0d678dacd3f3c7497d6f46f1c338c13bee1ac77", size = 3886 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Extend the solver in preparation for adding the information for the requirement for a metric.

This adds an adapter layer for determining what providers are available. Some magic might be needed there to deal with the fact that the Metric classes may not be directly available (because the ref package is installed out of process).

Still needs in follow up PRs

* Metric Run tables
* The ability to check if a metric needs to be run
* #15 
* Loading metrics from other packages

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
