### PR TITLE
Renames the projects to include cmip-ref- prefix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-
   imports-without-extras:
     strategy:
       fail-fast: false
@@ -142,3 +141,19 @@ jobs:
         run: |
           echo "No changelog present."
           exit 1
+
+  check-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - name: Check build
+        run: |
+          uv build --package cmip-ref -o dist
+          uv build --package cmip-ref-core -o dist
+          tar -tvf dist/cmip_ref-*.tar.gz --wildcards '*ref/py.typed' '*/LICENCE' '*/NOTICE'
+          tar -tvf dist/cmip_ref_core-*.tar.gz --wildcards '*ref_core/py.typed' '*/LICENCE' '*/NOTICE'
+      - name: Check installable
+        run: |
+          uv pip install dist/*.whl

--- a/packages/ref-core/README.md
+++ b/packages/ref-core/README.md
@@ -1,4 +1,7 @@
 # ref-core
 
 This package provides the core functionality for the REF.
-This package is designed to be a library so may be published and consumed by othe packages if needed.
+
+This package is designed to be a library so may be published and consumed by other packages if needed.
+
+See the [documentation](https://cmip-ref.readthedocs.io/en/latest/) for more information.

--- a/packages/ref-core/pyproject.toml
+++ b/packages/ref-core/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ref-core"
+name = "cmip-ref-core"
 version = "0.1.0"
 description = "Core library for the CMIP Rapid Evaluation Framework"
 readme = "README.md"
@@ -35,3 +35,14 @@ dev-dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["src/ref_core"]
+
+[tool.hatch.build.targets.sdist.force-include]
+"../../LICENCE" = "LICENCE"
+"../../NOTICE" = "NOTICE"
+
+[tool.hatch.build.targets.wheel.force-include]
+"../../../LICENCE" = "LICENCE"
+"../../../NOTICE" = "NOTICE"

--- a/packages/ref-metrics-example/pyproject.toml
+++ b/packages/ref-metrics-example/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ref-metrics-example"
+name = "cmip-ref-metrics-example"
 version = "0.1.0"
 description = "Example metrics provider for the CMIP Rapid Evaluation Framework"
 readme = "README.md"
@@ -11,6 +11,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
+    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -21,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "ref-core",
+    "cmip-ref-core",
     "xarray >= 2022",
     "netcdf4>=1.5.0",
     "dask>=2024.10.0",

--- a/packages/ref/pyproject.toml
+++ b/packages/ref/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ref"
+name = "cmip-ref"
 version = "0.1.0"
 description = "Application which runs the CMIP Rapid Evaluation Framework"
 readme = "README.md"
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "ref-core",
+    "cmip-ref-core",
     "attrs>=24.2.0",
     "cattrs>=24.1.2",
     "environs>=11.0.0",
@@ -51,3 +51,16 @@ dev-dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build]
+packages = ["src/ref"]
+
+[tool.hatch.build.targets.sdist.force-include]
+"../../README.md" = "README.md"
+"../../LICENCE" = "LICENCE"
+"../../NOTICE" = "NOTICE"
+
+[tool.hatch.build.targets.wheel.force-include]
+"../../../README.md" = "README.md"
+"../../../LICENCE" = "LICENCE"
+"../../../NOTICE" = "NOTICE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "cmip-ref"
+name = "cmip-ref-root"
 version = "0.1.0"
 description = "CMIP Rapid Evaluation Framework"
 readme = "README.md"
@@ -8,9 +8,9 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "ref[postgres]",
-    "ref-core",
-    "ref-metrics-example",
+    "cmip-ref[postgres]",
+    "cmip-ref-core",
+    "cmip-ref-metrics-example",
 ]
 
 [project.license]
@@ -54,9 +54,9 @@ dev-dependencies = [
 members = ["packages/*"]
 
 [tool.uv.sources]
-ref = { workspace = true }
-ref-core = { workspace = true }
-ref-metrics-example = { workspace = true }
+cmip-ref = { workspace = true }
+cmip-ref-core = { workspace = true }
+cmip-ref-metrics-example = { workspace = true }
 
 [tool.coverage.run]
 source = ["packages"]

--- a/uv.lock
+++ b/uv.lock
@@ -10,9 +10,9 @@ resolution-markers = [
 [manifest]
 members = [
     "cmip-ref",
-    "ref",
-    "ref-core",
-    "ref-metrics-example",
+    "cmip-ref-core",
+    "cmip-ref-metrics-example",
+    "cmip-ref-root",
 ]
 
 [[package]]
@@ -496,11 +496,78 @@ wheels = [
 [[package]]
 name = "cmip-ref"
 version = "0.1.0"
+source = { editable = "packages/ref" }
+dependencies = [
+    { name = "alembic" },
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "cmip-ref-core" },
+    { name = "ecgtools" },
+    { name = "environs" },
+    { name = "loguru" },
+    { name = "sqlalchemy" },
+    { name = "tomlkit" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+postgres = [
+    { name = "psycopg2-binary" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "alembic", specifier = ">=1.13.3" },
+    { name = "attrs", specifier = ">=24.2.0" },
+    { name = "cattrs", specifier = ">=24.1.2" },
+    { name = "cmip-ref-core", editable = "packages/ref-core" },
+    { name = "ecgtools", specifier = ">=2024.7.31" },
+    { name = "environs", specifier = ">=11.0.0" },
+    { name = "loguru", specifier = ">=0.7.2" },
+    { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.2" },
+    { name = "sqlalchemy", specifier = ">=2.0.36" },
+    { name = "tomlkit", specifier = ">=0.13.2" },
+    { name = "typer", specifier = ">=0.12.5" },
+]
+
+[[package]]
+name = "cmip-ref-core"
+version = "0.1.0"
+source = { editable = "packages/ref-core" }
+dependencies = [
+    { name = "attrs" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "attrs", specifier = ">=22.1.0" }]
+
+[[package]]
+name = "cmip-ref-metrics-example"
+version = "0.1.0"
+source = { editable = "packages/ref-metrics-example" }
+dependencies = [
+    { name = "cmip-ref-core" },
+    { name = "dask" },
+    { name = "netcdf4" },
+    { name = "xarray" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cmip-ref-core", editable = "packages/ref-core" },
+    { name = "dask", specifier = ">=2024.10.0" },
+    { name = "netcdf4", specifier = ">=1.5.0" },
+    { name = "xarray", specifier = ">=2022" },
+]
+
+[[package]]
+name = "cmip-ref-root"
+version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "ref", extra = ["postgres"] },
-    { name = "ref-core" },
-    { name = "ref-metrics-example" },
+    { name = "cmip-ref", extra = ["postgres"] },
+    { name = "cmip-ref-core" },
+    { name = "cmip-ref-metrics-example" },
 ]
 
 [package.dev-dependencies]
@@ -534,9 +601,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ref", extras = ["postgres"], editable = "packages/ref" },
-    { name = "ref-core", editable = "packages/ref-core" },
-    { name = "ref-metrics-example", editable = "packages/ref-metrics-example" },
+    { name = "cmip-ref", extras = ["postgres"], editable = "packages/ref" },
+    { name = "cmip-ref-core", editable = "packages/ref-core" },
+    { name = "cmip-ref-metrics-example", editable = "packages/ref-metrics-example" },
 ]
 
 [package.metadata.requires-dev]
@@ -3125,73 +3192,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/84/d0/d73525aeba800df7030ac187d09c59dc40df1c878b4fab8669bdc805535d/questionary-2.0.1.tar.gz", hash = "sha256:bcce898bf3dbb446ff62830c86c5c6fb9a22a54146f0f5597d3da43b10d8fc8b", size = 24726 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/e7/2dd8f59d1d328773505f78b85405ddb1cfe74126425d076ce72e65540b8b/questionary-2.0.1-py3-none-any.whl", hash = "sha256:8ab9a01d0b91b68444dff7f6652c1e754105533f083cbe27597c8110ecc230a2", size = 34248 },
-]
-
-[[package]]
-name = "ref"
-version = "0.1.0"
-source = { editable = "packages/ref" }
-dependencies = [
-    { name = "alembic" },
-    { name = "attrs" },
-    { name = "cattrs" },
-    { name = "ecgtools" },
-    { name = "environs" },
-    { name = "loguru" },
-    { name = "ref-core" },
-    { name = "sqlalchemy" },
-    { name = "tomlkit" },
-    { name = "typer" },
-]
-
-[package.optional-dependencies]
-postgres = [
-    { name = "psycopg2-binary" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "alembic", specifier = ">=1.13.3" },
-    { name = "attrs", specifier = ">=24.2.0" },
-    { name = "cattrs", specifier = ">=24.1.2" },
-    { name = "ecgtools", specifier = ">=2024.7.31" },
-    { name = "environs", specifier = ">=11.0.0" },
-    { name = "loguru", specifier = ">=0.7.2" },
-    { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.2" },
-    { name = "ref-core", editable = "packages/ref-core" },
-    { name = "sqlalchemy", specifier = ">=2.0.36" },
-    { name = "tomlkit", specifier = ">=0.13.2" },
-    { name = "typer", specifier = ">=0.12.5" },
-]
-
-[[package]]
-name = "ref-core"
-version = "0.1.0"
-source = { editable = "packages/ref-core" }
-dependencies = [
-    { name = "attrs" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "attrs", specifier = ">=22.1.0" }]
-
-[[package]]
-name = "ref-metrics-example"
-version = "0.1.0"
-source = { editable = "packages/ref-metrics-example" }
-dependencies = [
-    { name = "dask" },
-    { name = "netcdf4" },
-    { name = "ref-core" },
-    { name = "xarray" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "dask", specifier = ">=2024.10.0" },
-    { name = "netcdf4", specifier = ">=1.5.0" },
-    { name = "ref-core", editable = "packages/ref-core" },
-    { name = "xarray", specifier = ">=2022" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Replaces the `ref-` package prefix with `cmip-ref-` as the `ref` package is currently taken on PyPi


## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
