### PR TITLE
fix: Add version to the instance_id

### DIFF
--- a/changelog/35.fix.md
+++ b/changelog/35.fix.md
@@ -1,0 +1,1 @@
+Adds `version` field to the `instance_id` field for CMIP6 datasets

--- a/packages/ref-core/tests/unit/test_datasets.py
+++ b/packages/ref-core/tests/unit/test_datasets.py
@@ -42,7 +42,7 @@ class TestMetricDataset:
         )
 
     def test_slug(self, metric_dataset):
-        assert metric_dataset.hash == "69165f25de10cc0b682e6d1acd1026c0ad27448c"
+        assert metric_dataset.hash == "33cf5324201ff57067b548077f3bb26d9a7d9def"
 
 
 class TestDatasetCollection:
@@ -57,7 +57,7 @@ class TestDatasetCollection:
     def test_hash(self, dataset_collection, cmip6_data_catalog):
         dataset_hash = hash(dataset_collection)
         assert isinstance(dataset_hash, int)
-        assert dataset_hash == 162057064475757030
+        assert dataset_hash == 1411607912180158146
 
         assert dataset_hash == hash(DatasetCollection(cmip6_data_catalog, "instance_id"))
         assert dataset_hash != hash(

--- a/packages/ref/src/ref/datasets/cmip6.py
+++ b/packages/ref/src/ref/datasets/cmip6.py
@@ -147,6 +147,7 @@ class CMIP6DatasetAdapter(DatasetAdapter):
             "table_id",
             "variable_id",
             "grid_label",
+            "version",
         ]
         datasets["instance_id"] = datasets.apply(
             lambda row: "CMIP6." + ".".join([row[item] for item in drs_items]), axis=1

--- a/packages/ref/tests/unit/datasets/test_cmip6/cmip6_catalog_db.yml
+++ b/packages/ref/tests/unit/datasets/test_cmip6/cmip6_catalog_db.yml
@@ -9,7 +9,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rlut.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rlut.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Outgoing Longwave Radiation
   member_id: r1i1p1f1
@@ -45,7 +45,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rlut.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rlut.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Outgoing Longwave Radiation
   member_id: r1i1p1f1
@@ -81,7 +81,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsdt.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsdt.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Incident Shortwave Radiation
   member_id: r1i1p1f1
@@ -117,7 +117,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsdt.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsdt.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Incident Shortwave Radiation
   member_id: r1i1p1f1
@@ -153,7 +153,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsut.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsut.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Outgoing Shortwave Radiation
   member_id: r1i1p1f1
@@ -189,7 +189,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsut.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsut.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Outgoing Shortwave Radiation
   member_id: r1i1p1f1
@@ -225,7 +225,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn.v20210318
   institution_id: CSIRO
   long_name: Near-Surface Air Temperature
   member_id: r1i1p1f1
@@ -261,7 +261,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn.v20210318
   institution_id: CSIRO
   long_name: Near-Surface Air Temperature
   member_id: r1i1p1f1
@@ -297,7 +297,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.fx.areacella.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.fx.areacella.gn.v20210318
   institution_id: CSIRO
   long_name: Grid-Cell Area for Atmospheric Grid Variables
   member_id: r1i1p1f1

--- a/packages/ref/tests/unit/datasets/test_cmip6/cmip6_catalog_local.yml
+++ b/packages/ref/tests/unit/datasets/test_cmip6/cmip6_catalog_local.yml
@@ -9,7 +9,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rlut.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rlut.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Outgoing Longwave Radiation
   member_id: r1i1p1f1
@@ -46,7 +46,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rlut.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rlut.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Outgoing Longwave Radiation
   member_id: r1i1p1f1
@@ -83,7 +83,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsdt.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsdt.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Incident Shortwave Radiation
   member_id: r1i1p1f1
@@ -120,7 +120,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsdt.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsdt.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Incident Shortwave Radiation
   member_id: r1i1p1f1
@@ -157,7 +157,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsut.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsut.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Outgoing Shortwave Radiation
   member_id: r1i1p1f1
@@ -194,7 +194,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsut.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsut.gn.v20210318
   institution_id: CSIRO
   long_name: TOA Outgoing Shortwave Radiation
   member_id: r1i1p1f1
@@ -231,7 +231,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn.v20210318
   institution_id: CSIRO
   long_name: Near-Surface Air Temperature
   member_id: r1i1p1f1
@@ -268,7 +268,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn.v20210318
   institution_id: CSIRO
   long_name: Near-Surface Air Temperature
   member_id: r1i1p1f1
@@ -305,7 +305,7 @@
   grid: native atmosphere N96 grid (145x192 latxlon)
   grid_label: gn
   init_year: null
-  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.fx.areacella.gn
+  instance_id: CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.fx.areacella.gn.v20210318
   institution_id: CSIRO
   long_name: Grid-Cell Area for Atmospheric Grid Variables
   member_id: r1i1p1f1

--- a/packages/ref/tests/unit/test_solver.py
+++ b/packages/ref/tests/unit/test_solver.py
@@ -192,8 +192,8 @@ def test_solve_metrics(mock_executor, db_seeded, solver):
     definitions = [call.kwargs["definition"] for call in mock_executor.return_value.run_metric.mock_calls]
 
     expected_instance_ids = [
-        ["CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn"],
-        ["CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsut.gn"],
+        ["CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.tas.gn.v20210318"],
+        ["CMIP6.ScenarioMIP.CSIRO.ACCESS-ESM1-5.ssp126.r1i1p1f1.Amon.rsut.gn.v20210318"],
     ]
     expected_keys = [
         "ACCESS-ESM1-5_rsut_ssp126_r1i1p1f1",


### PR DESCRIPTION
## Description
Adds the version field to the instance_id. 
This makes sure that the hash will change if new versions of datasets become available.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
