### PR TITLE
feat: Fixes from ingesting more datasets

### DIFF
--- a/changelog/36.feature.md
+++ b/changelog/36.feature.md
@@ -1,0 +1,3 @@
+Added option to skip any datasets that fail validation and to specify the number of cores to
+use when ingesting datasets.
+This behaviour can be opted in using the `--skip-invalid` and `--n-jobs` options respectively.

--- a/packages/ref/src/ref/datasets/__init__.py
+++ b/packages/ref/src/ref/datasets/__init__.py
@@ -2,7 +2,7 @@
 Dataset handling utilities
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ref_core.datasets import SourceDatasetType
 
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ref.datasets.base import DatasetAdapter
 
 
-def get_dataset_adapter(source_type: str) -> "DatasetAdapter":
+def get_dataset_adapter(source_type: str, **kwargs: Any) -> "DatasetAdapter":
     """
     Get the appropriate adapter for the specified source type
 
@@ -27,6 +27,6 @@ def get_dataset_adapter(source_type: str) -> "DatasetAdapter":
     if source_type.lower() == SourceDatasetType.CMIP6.value:
         from ref.datasets.cmip6 import CMIP6DatasetAdapter
 
-        return CMIP6DatasetAdapter()
+        return CMIP6DatasetAdapter(**kwargs)
     else:
         raise ValueError(f"Unknown source type: {source_type}")

--- a/packages/ref/src/ref/datasets/base.py
+++ b/packages/ref/src/ref/datasets/base.py
@@ -2,10 +2,30 @@ from pathlib import Path
 from typing import Protocol
 
 import pandas as pd
+from loguru import logger
 
 from ref.config import Config
 from ref.database import Database
 from ref.models.dataset import Dataset
+
+
+def _log_duplicate_metadata(data_catalog, unique_metadata):
+    # Drop out the rows where the values are the same
+    invalid_datasets = unique_metadata[unique_metadata.gt(1).any(axis=1)]
+    # Drop out the columns where the values are the same
+    invalid_datasets = invalid_datasets[invalid_datasets.columns[invalid_datasets.gt(1).any(axis=0)]]
+
+    for instance_id in invalid_datasets.index:
+        # Get the columns where the values are different
+        invalid_dataset_nunique = invalid_datasets.loc[instance_id]
+        invalid_dataset_columns = invalid_dataset_nunique[invalid_dataset_nunique.gt(1)].index.tolist()
+        invalid_dataset_columns.append("time_range")
+
+        data_catalog_subset = data_catalog[data_catalog.instance_id == instance_id]
+
+        logger.error(
+            f"Dataset {instance_id} has varying metadata:\n{data_catalog_subset[invalid_dataset_columns]}"
+        )
 
 
 class DatasetAdapter(Protocol):
@@ -43,7 +63,7 @@ class DatasetAdapter(Protocol):
         """
         ...
 
-    def validate_data_catalog(self, data_catalog: pd.DataFrame) -> pd.DataFrame:
+    def validate_data_catalog(self, data_catalog: pd.DataFrame, skip_invalid: bool = False) -> pd.DataFrame:
         """
         Validate a data catalog
 
@@ -51,6 +71,13 @@ class DatasetAdapter(Protocol):
         ----------
         data_catalog
             Data catalog to validate
+        skip_invalid
+            If True, ignore datasets with invalid metadata and remove them from the resulting data catalog.
+
+        Raises
+        ------
+        ValueError
+            If `skip_invalid` is False (default) and the data catalog contains validation errors.
 
         Returns
         -------
@@ -70,13 +97,16 @@ class DatasetAdapter(Protocol):
             data_catalog[list(self.dataset_specific_metadata)].groupby(self.slug_column).nunique()
         )
         if unique_metadata.gt(1).any(axis=1).any():
-            # Drop out the rows where the values are the same
-            invalid_datasets = unique_metadata[unique_metadata.gt(1).any(axis=1)]
-            # Drop out the columns where the values are the same
-            invalid_datasets = invalid_datasets[invalid_datasets.gt(1)].dropna(axis=1)
-            raise ValueError(
-                f"Dataset specific metadata varies by dataset.\nUnique values: {invalid_datasets}"
-            )
+            _log_duplicate_metadata(data_catalog, unique_metadata)
+
+            if skip_invalid:
+                data_catalog = data_catalog[
+                    ~data_catalog[self.slug_column].isin(
+                        unique_metadata[unique_metadata.gt(1).any(axis=1)].index
+                    )
+                ]
+            else:
+                raise ValueError("Dataset specific metadata varies by dataset")
 
         return data_catalog
 

--- a/packages/ref/src/ref/datasets/cmip6.py
+++ b/packages/ref/src/ref/datasets/cmip6.py
@@ -23,7 +23,7 @@ def _parse_datetime(dt_str: pd.Series[str]) -> pd.Series[datetime | Any]:
     Pandas tries to coerce everything to their own datetime format, which is not what we want here.
     """
 
-    def _inner(date_string):
+    def _inner(date_string: str | None) -> datetime | None:
         if not date_string:
             return None
 

--- a/packages/ref/src/ref/datasets/cmip6.py
+++ b/packages/ref/src/ref/datasets/cmip6.py
@@ -191,7 +191,7 @@ class CMIP6DatasetAdapter(DatasetAdapter):
 
         # Temporary fix for some datasets
         # TODO: Replace with a standalone package that contains metadata fixes for CMIP6 datasets
-        datasets = _apply_fixes(datasets).reset_index()
+        datasets = _apply_fixes(datasets)
 
         return datasets
 

--- a/packages/ref/tests/unit/datasets/test_cmip6.py
+++ b/packages/ref/tests/unit/datasets/test_cmip6.py
@@ -1,7 +1,9 @@
+import datetime
+
 import pandas as pd
 import pytest
 
-from ref.datasets.cmip6 import CMIP6DatasetAdapter
+from ref.datasets.cmip6 import CMIP6DatasetAdapter, _parse_datetime
 
 
 @pytest.fixture
@@ -13,6 +15,17 @@ def catalog_regression(data_regression, esgf_data_dir):
         data_regression.check(df.to_dict(orient="records"), basename=basename)
 
     return check
+
+
+def test_parse_datetime():
+    pd.testing.assert_series_equal(
+        _parse_datetime(pd.Series(["2021-01-01 00:00:00", "1850-01-17 00:29:59.999993"])),
+        pd.Series(
+            [datetime.datetime(2021, 1, 1, 0, 0), datetime.datetime(1850, 1, 17, 0, 29, 59, 999993)],
+            dtype="object",
+        ),
+    )
+    pass
 
 
 class TestCMIP6Adapter:

--- a/packages/ref/tests/unit/datasets/test_cmip6.py
+++ b/packages/ref/tests/unit/datasets/test_cmip6.py
@@ -25,7 +25,6 @@ def test_parse_datetime():
             dtype="object",
         ),
     )
-    pass
 
 
 class TestCMIP6Adapter:

--- a/packages/ref/tests/unit/datasets/test_cmip6.py
+++ b/packages/ref/tests/unit/datasets/test_cmip6.py
@@ -19,9 +19,9 @@ def catalog_regression(data_regression, esgf_data_dir):
 
 def test_parse_datetime():
     pd.testing.assert_series_equal(
-        _parse_datetime(pd.Series(["2021-01-01 00:00:00", "1850-01-17 00:29:59.999993"])),
+        _parse_datetime(pd.Series(["2021-01-01 00:00:00", "1850-01-17 00:29:59.999993", None])),
         pd.Series(
-            [datetime.datetime(2021, 1, 1, 0, 0), datetime.datetime(1850, 1, 17, 0, 29, 59, 999993)],
+            [datetime.datetime(2021, 1, 1, 0, 0), datetime.datetime(1850, 1, 17, 0, 29, 59, 999993), None],
             dtype="object",
         ),
     )


### PR DESCRIPTION
## Description

Rework how we log messages from validation errors.
I managed to import ~2k tas datasets and got some informative log messages when things went wrong. As expected there were lots of inconsistencies and this is only checking that the files in a dataset all have the same metadata, rather than them being correct.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

Fixes #34 