### PR TITLE
fix: Make config name consistent

### DIFF
--- a/changelog/82.fix.md
+++ b/changelog/82.fix.md
@@ -1,0 +1,1 @@
+Correct the expected configuration name to `ref.toml` as per the documentation.

--- a/conftest.py
+++ b/conftest.py
@@ -43,7 +43,7 @@ def config(tmp_path, monkeypatch) -> Config:
     monkeypatch.setenv("REF_CONFIGURATION", str(tmp_path / "cmip_ref"))
 
     # Uses the default configuration
-    cfg = Config.load(tmp_path / "cmip_ref" / "cmip_ref.toml")
+    cfg = Config.load(tmp_path / "cmip_ref" / "ref.toml")
 
     # Allow adding datasets from outside the tree for testing
     cfg.paths.allow_out_of_tree_datasets = True

--- a/packages/ref/src/cmip_ref/constants.py
+++ b/packages/ref/src/cmip_ref/constants.py
@@ -2,7 +2,7 @@
 Constants used by the REF
 """
 
-config_filename = "cmip_ref.toml"
+config_filename = "ref.toml"
 """
 Default name of the configuration file
 """

--- a/packages/ref/tests/unit/test_config.py
+++ b/packages/ref/tests/unit/test_config.py
@@ -12,16 +12,16 @@ class TestConfig:
 
         # The configuration file doesn't exist
         # so it should default to some sane defaults
-        assert not (tmp_path / "cmip_ref.toml").exists()
+        assert not (tmp_path / "ref.toml").exists()
 
-        loaded = Config.load(Path("cmip_ref.toml"))
+        loaded = Config.load(Path("ref.toml"))
 
         assert loaded.paths.data == tmp_path / "cmip_ref" / "data"
 
         # The results aren't serialised back to disk
-        assert not (tmp_path / "cmip_ref.toml").exists()
+        assert not (tmp_path / "ref.toml").exists()
         assert loaded._raw is None
-        assert loaded._config_file == Path("cmip_ref.toml")
+        assert loaded._config_file == Path("ref.toml")
 
     def test_default(self, config):
         config.paths.data = "data"
@@ -34,10 +34,10 @@ class TestConfig:
     def test_load(self, config, tmp_path):
         res = config.dump(defaults=True)
 
-        with open(tmp_path / "cmip_ref.toml", "w") as fh:
+        with open(tmp_path / "ref.toml", "w") as fh:
             fh.write(res.as_string())
 
-        loaded = Config.load(tmp_path / "cmip_ref.toml")
+        loaded = Config.load(tmp_path / "ref.toml")
 
         assert config.dumps() == loaded.dumps()
 
@@ -50,7 +50,7 @@ extra = "extra"
 filename = "sqlite://cmip_ref.db"
 """
 
-        with open(tmp_path / "cmip_ref.toml", "w") as fh:
+        with open(tmp_path / "ref.toml", "w") as fh:
             fh.write(content)
 
         # cattrs exceptions are a bit ugly, but you get an exception like this:
@@ -68,7 +68,7 @@ filename = "sqlite://cmip_ref.db"
         #       | cattrs.errors.ForbiddenExtraKeysError: Extra fields in constructor for Paths: extra
 
         with pytest.raises(cattrs.errors.ClassValidationError):
-            Config.load(tmp_path / "cmip_ref.toml")
+            Config.load(tmp_path / "ref.toml")
 
     def test_save(self, tmp_path):
         config = Config(paths=Paths(data=Path("data")))
@@ -77,9 +77,9 @@ filename = "sqlite://cmip_ref.db"
             # The configuration file hasn't been set as it was created directly
             config.save()
 
-        config.save(tmp_path / "cmip_ref.toml")
+        config.save(tmp_path / "ref.toml")
 
-        assert (tmp_path / "cmip_ref.toml").exists()
+        assert (tmp_path / "ref.toml").exists()
 
     def test_defaults(self, monkeypatch):
         monkeypatch.setenv("REF_CONFIGURATION", "test")


### PR DESCRIPTION
## Description

Reverts back to use `ref.toml` as the name of the configuration file as per the docs. This was missed in the refactor to the new package names #53 .

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
