### PR TITLE
Integrate the celery CLI into the ref cli

### DIFF
--- a/changelog/86.feature.md
+++ b/changelog/86.feature.md
@@ -1,0 +1,3 @@
+Add the `cmip_ref_celery` CLI commands to the `ref` CLI tool.
+These commands should be available when the `cmip_ref_celery` package is installed.
+The commands should be available in the `ref` CLI tool as `ref celery ...`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       dockerfile: packages/ref/Dockerfile
       platforms:
         - linux/amd64
-    command: ref-celery
+    command: celery start-worker
     volumes:
       - .esgpull/data:/esgf
       - ./out:/output
@@ -42,7 +42,7 @@ services:
       - CELERY_BROKER_URL=redis://redis:6379/1
       - REF_OUTPUT_ROOT=/output
       - REF_DATA_ROOT=/esgf
-    command: ref-celery --package cmip-ref-metrics-example
+    command: celery start-worker --package cmip-ref-metrics-example
     volumes:
       - .esgpull/data:/esgf
       - ./out:/output

--- a/packages/ref-celery/README.md
+++ b/packages/ref-celery/README.md
@@ -4,7 +4,7 @@ This package provides celery task generation from Provider and Metric definition
 
 ## CLI tool
 
-The `ref-celery` package provides a CLI tool to start a worker instance from a REF metrics provider.
+The `cmip_ref_celery` package provides a CLI tool to start a worker instance from a REF metrics provider.
 This worker instance will listen for tasks related to a provider and execute them.
 The compute engine worker will then collect the results of these tasks and store them in the database.
 This allows for the REF to be run in a distributed manner,
@@ -15,11 +15,18 @@ with multiple workers running on different machines with a centrally managed dat
 For example, to start a worker instance for the `cmip_ref_metrics_example` package:
 
 ```bash
-ref-celery --package cmip_ref_metrics_example
+ref-celery start-worker --package cmip_ref_metrics_example
 ```
 
 This requires the `cmip_ref_metrics_example` package to be installed in the current virtual environment.
 
+If the `cmip_ref` package is also installed,
+the celery CLI command is available via the `ref` CLI tool.
+The equivalent command to the above is:
+
+```bash
+ref celery start-worker --package cmip_ref_metrics_example
+```
 
 ### Configuration
 

--- a/packages/ref-celery/src/cmip_ref_celery/cli.py
+++ b/packages/ref-celery/src/cmip_ref_celery/cli.py
@@ -1,5 +1,5 @@
 """
-CLI for the ref-celery package.
+Managing remote execution workers
 """
 
 import importlib
@@ -10,7 +10,7 @@ from cmip_ref_celery.app import create_celery_app
 from cmip_ref_celery.tasks import register_celery_tasks
 from cmip_ref_core.providers import MetricsProvider
 
-app = typer.Typer()
+app = typer.Typer(help=__doc__)
 
 
 def import_provider(provider_package: str) -> MetricsProvider:
@@ -79,6 +79,16 @@ def start_worker(
 
     argv = ["worker", f"--loglevel={loglevel}", *(extra_args or [])]
     celery_app.worker_main(argv=argv)
+
+
+@app.command()
+def list_config() -> None:
+    """
+    List the celery configuration
+    """
+    celery_app = create_celery_app("cmip_ref_celery")
+
+    print(celery_app.conf.humanize())
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/packages/ref/src/cmip_ref/config.py
+++ b/packages/ref/src/cmip_ref/config.py
@@ -224,7 +224,7 @@ class Config:
 
 
 def _make_converter(omit_default: bool) -> Converter:
-    conv = Converter(omit_if_default=omit_default)
+    conv = Converter(omit_if_default=omit_default, forbid_extra_keys=True)
     conv.register_unstructure_hook(Path, str)
     conv.register_unstructure_hook(
         Config,

--- a/packages/ref/src/cmip_ref/config.py
+++ b/packages/ref/src/cmip_ref/config.py
@@ -224,7 +224,7 @@ class Config:
 
 
 def _make_converter(omit_default: bool) -> Converter:
-    conv = Converter(omit_if_default=omit_default, forbid_extra_keys=True)
+    conv = Converter(omit_if_default=omit_default)
     conv.register_unstructure_hook(Path, str)
     conv.register_unstructure_hook(
         Config,

--- a/packages/ref/tests/unit/cli/test_root.py
+++ b/packages/ref/tests/unit/cli/test_root.py
@@ -1,4 +1,5 @@
 from cmip_ref import __version__
+from cmip_ref.cli import build_app
 from cmip_ref_core import __version__ as __core_version__
 
 
@@ -54,3 +55,24 @@ def test_config_directory_append(config, invoke_cli):
         ],
         expected_exit_code=2,
     )
+
+
+def test_build_app():
+    app = build_app()
+
+    registered_commands = [command.name for command in app.registered_commands]
+    registered_groups = [group.name for group in app.registered_groups]
+
+    assert ["solve"] == registered_commands
+    assert ["config", "datasets", "celery"] == registered_groups
+
+
+def test_build_app_without_celery(mocker):
+    mocker.patch("cmip_ref.cli.importlib.import_module", side_effect=ModuleNotFoundError)
+    app = build_app()
+
+    registered_commands = [command.name for command in app.registered_commands]
+    registered_groups = [group.name for group in app.registered_groups]
+
+    assert ["solve"] == registered_commands
+    assert ["config", "datasets"] == registered_groups


### PR DESCRIPTION
## Description

Optionally adds the celery CLI commands into the ref CLI.

This is useful in the docker container as the default entrypoint is the REF CLI and any additional commands are passed to this CLIi.e. running `docker run ref celery start-worker` would run the `ref` image with `celery start-worker` which is equivalent to running `uv run ref celery start-worker` locally. 

The alternative is to change the entrypoint in the docker-compose file, but that isn't as clean. Nor is adding the celery commands to the `ref` package. This has a better separation of concerns.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
