### PR TITLE
Speed up tests and clean up some warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,14 +108,22 @@ test-integration:  ## run the integration tests
 		pytest tests \
 		-r a -v
 
-.PHONY: test-metric-packages
-test-metric-packages: test-metrics-example test-metrics-esmvaltool test-metrics-ilamb test-metrics-pmp
+.PHONY: test-metrics-packages
+test-metrics-packages: test-metrics-example test-metrics-esmvaltool test-metrics-ilamb test-metrics-pmp
 
 .PHONY: test-executors
 test-executors: test-celery
 
 .PHONY: test
 test: clean test-core test-ref test-executors test-metric-packages test-integration ## run the tests
+
+.PHONY: test-quick
+test-quick: clean  ## run all the tests at once
+	# This is a quicker way of running all the tests
+	# It doesn't execute each test using the target package as above
+	uv run \
+		pytest tests packages \
+		-r a -v  --cov-report=term
 
 # Note on code coverage and testing:
 # If you want to debug what is going on with coverage, we have found

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ test-metrics-packages: test-metrics-example test-metrics-esmvaltool test-metrics
 test-executors: test-celery
 
 .PHONY: test
-test: clean test-core test-ref test-executors test-metric-packages test-integration ## run the tests
+test: clean test-core test-ref test-executors test-metrics-packages test-integration ## run the tests
 
 .PHONY: test-quick
 test-quick: clean  ## run all the tests at once

--- a/changelog/103.improvement.md
+++ b/changelog/103.improvement.md
@@ -1,0 +1,1 @@
+Sped up the test suite execution

--- a/conftest.py
+++ b/conftest.py
@@ -21,7 +21,7 @@ from cmip_ref_core.metrics import DataRequirement, MetricExecutionDefinition, Me
 from cmip_ref_core.providers import MetricsProvider
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def sample_data_dir() -> Path:
     return TEST_DATA_DIR / "sample-data"
 
@@ -32,7 +32,7 @@ def sample_data() -> None:
     fetch_sample_data(force_cleanup=False, symlink=False)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def cmip6_data_catalog(sample_data_dir) -> pd.DataFrame:
     adapter = CMIP6DatasetAdapter()
     return adapter.find_local_datasets(sample_data_dir / "CMIP6")

--- a/conftest.py
+++ b/conftest.py
@@ -49,8 +49,6 @@ def config(tmp_path, monkeypatch) -> Config:
     cfg.paths.allow_out_of_tree_datasets = True
     cfg.metric_providers = [MetricsProviderConfig(provider="cmip_ref_metrics_example")]
 
-    # Use a SQLite in-memory database for testing
-    # cfg.db.database_url = "sqlite:///:memory:"
     cfg.save()
 
     return cfg

--- a/packages/ref-metrics-example/src/cmip_ref_metrics_example/example.py
+++ b/packages/ref-metrics-example/src/cmip_ref_metrics_example/example.py
@@ -28,7 +28,8 @@ def calculate_annual_mean_timeseries(input_files: list[Path]) -> xr.Dataset:
     :
         The annual mean timeseries of the dataset
     """
-    xr_ds = xr.open_mfdataset(input_files, combine="by_coords", chunks=None, use_cftime=True)
+    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+    xr_ds = xr.open_mfdataset(input_files, combine="by_coords", chunks=None, decode_times=time_coder)
 
     annual_mean = xr_ds.resample(time="YS").mean()
     return annual_mean.weighted(xr_ds.areacella).mean(dim=["lat", "lon"], keep_attrs=True)

--- a/packages/ref-metrics-ilamb/src/cmip_ref_metrics_ilamb/example.py
+++ b/packages/ref-metrics-ilamb/src/cmip_ref_metrics_ilamb/example.py
@@ -22,7 +22,8 @@ def calculate_global_mean_timeseries(input_files: list[Path]) -> xr.Dataset:
     :
         The annual mean timeseries of the dataset
     """
-    ds = xr.open_mfdataset(input_files, combine="by_coords", chunks=None, use_cftime=True)
+    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+    ds = xr.open_mfdataset(input_files, combine="by_coords", chunks=None, decode_times=time_coder)
     mean: xr.Dataset = integrate_space(ds, "tas", mean=True).to_dataset()
     return mean
 

--- a/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/example.py
+++ b/packages/ref-metrics-pmp/src/cmip_ref_metrics_pmp/example.py
@@ -27,7 +27,8 @@ def calculate_annual_cycle(input_files: list[Path]) -> xr.Dataset:
     :
         The annual mean timeseries of the dataset
     """
-    xr_ds = xr.open_mfdataset(input_files, combine="by_coords", chunks=None, use_cftime=True)
+    time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+    xr_ds = xr.open_mfdataset(input_files, combine="by_coords", chunks=None, decode_times=time_coder)
 
     annual_mean = xr_ds.resample(time="YS").mean()
     return annual_mean.mean(dim=["lat", "lon"], keep_attrs=True)

--- a/packages/ref/src/cmip_ref/datasets/cmip6.py
+++ b/packages/ref/src/cmip_ref/datasets/cmip6.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -165,12 +166,16 @@ class CMIP6DatasetAdapter(DatasetAdapter):
         :
             Data catalog containing the metadata for the dataset
         """
-        builder = Builder(
-            paths=[str(file_or_directory)],
-            depth=10,
-            include_patterns=["*.nc"],
-            joblib_parallel_kwargs={"n_jobs": self.n_jobs},
-        ).build(parsing_func=ecgtools.parsers.parse_cmip6)
+        with warnings.catch_warnings():
+            # Ignore the DeprecationWarning from xarray
+            warnings.simplefilter("ignore", DeprecationWarning)
+
+            builder = Builder(
+                paths=[str(file_or_directory)],
+                depth=10,
+                include_patterns=["*.nc"],
+                joblib_parallel_kwargs={"n_jobs": self.n_jobs},
+            ).build(parsing_func=ecgtools.parsers.parse_cmip6)
 
         datasets = builder.df
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,8 +123,9 @@ addopts = [
     "--import-mode=importlib",
 ]
 filterwarnings = [
-    # Need to update ecgtools to remove this warning
+    # Need to update ecgtools/intake_esm to remove this warning
     'ignore:The `validate_arguments` method is deprecated:pydantic.warnings.PydanticDeprecatedSince20',
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
 ]
 
 # We currently check for GPL licensed code, but this restriction may be removed


### PR DESCRIPTION
## Description

* Cleans up the a bunch of warnings about the time decoding from newer versions of xarray
* Speeding up the test suite by marking some fixures as session scoped and caching the seeded db for reuse
* Adds a `make test-quick` to run the test suite using the root package rather than targetting each descrete packages

All in all this made the test suite runtime go from 45s to 30 for the full test suite (`make test`) and 9.5s for the quick test suite (`make test-quick`).

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
