### PR TITLE
Add ignore datasets constraint and configuration file

### DIFF
--- a/changelog/447.feature.md
+++ b/changelog/447.feature.md
@@ -1,0 +1,5 @@
+Added ignore datasets constraint and configuration file.
+
+If no path is configured for the `ignore_datasets_file` in the configuration file,
+the default ignore datasets file is downloaded from the Climate-REF GitHub repository
+if it does not exist or is older than 6 hours.

--- a/default_ignore_datasets.yaml
+++ b/default_ignore_datasets.yaml
@@ -1,0 +1,30 @@
+# This file is used to specify datasets that should be ignored by default.
+#
+# It can be used to ignore datasets that are known to have issues and keep
+# diagnostics that use multiple datasets from running.
+#
+# The format used in this configuration file is:
+# provider:
+#   diagnostic:
+#     source_type:
+#       - facet: value
+#       - other_facet: [other_value1, other_value2]
+#
+# The facets listed here will be used to create `climate_ref_core.constraints.IgnoreFacets`
+# instances that will be prepended to the constraints of the data requirements
+# of the diagnostics that the facets are listed under.
+#
+# If no `ignore_datasets_file` is specified in the REF configuration, this file
+# will be downloaded from GitHub and used. If the local copy of this file is
+# older than 6 hours, it will be updated.
+#
+esmvaltool:
+  sea-ice-sensitivity:
+      cmip6:
+        - experiment_id: historical
+          grid_label: gn
+          member_id: r1i1p1f1
+          source_id: CAS-ESM2-0
+          table_id: SImon
+          variable_id: siconc
+          version: v20201225


### PR DESCRIPTION
## Description

Add a constraint and configuration file that can be used to ignore specific datasets.

This is needed to support filtering out datasets that crash multi-model analyses as reported in #425.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
