### PR TITLE
fix(helm): use distinct chart version tags per build context

### DIFF
--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -67,7 +67,14 @@ jobs:
       id: semantic-version
       run: |
         CHART_VERSION=$(yq -r '.version' helm/Chart.yaml)
-        LOCAL_SEGMENT=+pr-${{ github.event.pull_request.number }}
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          LOCAL_SEGMENT=+pr-${{ github.event.pull_request.number }}
+        elif [ "${{ github.ref_type }}" = "tag" ]; then
+          LOCAL_SEGMENT=""
+        else
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          LOCAL_SEGMENT=+${SHORT_SHA}
+        fi
         GENERATED_VERSION=${CHART_VERSION}${LOCAL_SEGMENT}
         yq -Y -i ".version = \"$GENERATED_VERSION\"" helm/Chart.yaml
         echo "generated-semver=$GENERATED_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Fix packaging workflow that unconditionally appended `+pr-{number}` to chart versions, producing malformed tags like `0.9.1+pr-` on non-PR builds
- Chart tags are now context-dependent:
  - **PR builds**: `{version}+pr-{number}` (e.g. `0.9.1+pr-492`)
  - **Main pushes**: `{version}+{sha}` (e.g. `0.9.1+f7a97e0`)
  - **Tag/release pushes**: `{version}` (e.g. `0.9.1`)

## Test plan

- [x] Verify PR build produces `0.9.1+pr-{number}` tag
- [x] After merge, verify main push produces `0.9.1+{sha}` tag
- [x] On next release, verify clean `0.9.1` tag is published