### PR TITLE
Replace out_name by variable_id in CMIP7 paths

### DIFF
--- a/changelog/539.fix.md
+++ b/changelog/539.fix.md
@@ -1,0 +1,1 @@
+Fixed confusion between variable_id and out_name in fake CMIP7 data.

--- a/packages/climate-ref-core/src/climate_ref_core/constraints.py
+++ b/packages/climate-ref-core/src/climate_ref_core/constraints.py
@@ -156,10 +156,22 @@ class RequireFacets:
         groups = [group] if not self.group_by else (g[1] for g in group.groupby(list(self.group_by)))
         for subgroup in groups:
             if not op(value in subgroup[self.dimension].values for value in self.required_facets):
-                logger.debug(
-                    f"Constraint {self} not satisfied because required facet values "
-                    f"not found for group {', '.join(subgroup['path'])}"
-                )
+                if self.operator == "all":
+                    missing_values = [
+                        f"'{value}'"
+                        for value in self.required_facets
+                        if value not in subgroup[self.dimension].values
+                    ]
+                    logger.debug(
+                        f"Constraint {self} not satisfied because required facet values "
+                        f"{', '.join(missing_values)} not found for group "
+                        f"{', '.join(sorted(subgroup['path']))}"
+                    )
+                else:
+                    logger.debug(
+                        f"Constraint {self} not satisfied because none of the required facet values "
+                        f"were found for group {', '.join(sorted(subgroup['path']))}"
+                    )
                 select.loc[subgroup.index] = False
         return group[select]
 

--- a/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
+++ b/packages/climate-ref-core/src/climate_ref_core/esgf/cmip7.py
@@ -66,7 +66,7 @@ def _convert_file_to_cmip7(cmip6_path: Path, cmip7_facets: dict[str, Any]) -> Pa
         str(cmip7_facets.get("experiment_id", "historical")),
         str(cmip7_facets.get("variant_label", "r1i1p1f1")),
         str(cmip7_facets.get("frequency", "mon")),
-        str(cmip7_facets.get("out_name", cmip7_facets.get("variable_id", "tas"))),
+        str(cmip7_facets.get("variable_id", "tas")),
         str(cmip7_facets.get("grid_label", "gn")),
         version,
     )
@@ -192,8 +192,8 @@ class CMIP7Request:
     def _convert_to_cmip7_metadata(self, cmip6_row: dict[str, Any]) -> dict[str, Any]:
         """Convert CMIP6 metadata to CMIP7 format.
 
-        This is the single location for DReq enrichment: it adds
-        ``region``, ``branding_suffix``, ``out_name``, and
+        This is the single location for DReq enrichment: it updates
+        ``variable_id`` and adds ``region``, ``branding_suffix``, and
         ``branded_variable`` from the Data Request when available.
         """
         cmip7_row = dict(cmip6_row)
@@ -228,9 +228,9 @@ class CMIP7Request:
             try:
                 entry = get_dreq_entry(table_id, variable_id)
                 cmip7_row["region"] = entry.region
+                cmip7_row["variable_id"] = entry.branded_variable.split("_")[0]
                 cmip7_row["branding_suffix"] = entry.branding_suffix
-                cmip7_row["out_name"] = entry.out_name
-                cmip7_row["branded_variable"] = f"{entry.out_name}_{entry.branding_suffix}"
+                cmip7_row["branded_variable"] = entry.branded_variable
             except KeyError:
                 logger.debug(
                     f"No DReq entry for {table_id}.{variable_id}, region/branding_suffix will not be set"

--- a/packages/climate-ref-core/tests/unit/esgf/test_cmip7.py
+++ b/packages/climate-ref-core/tests/unit/esgf/test_cmip7.py
@@ -251,7 +251,6 @@ class TestConvertFileToCmip7:
             "table_id": "Amon",
             "grid_label": "gn",
             "version": "v1",
-            "out_name": "tas",
             "branding_suffix": "tavg-h2m-hxy-u",
             "region": "glb",
         }
@@ -309,7 +308,6 @@ class TestConvertFileToCmip7:
             "table_id": "Amon",
             "grid_label": "gn",
             "version": "v1",
-            "out_name": "tas",
             "branding_suffix": "tavg-h2m-hxy-u",
             "region": "glb",
         }
@@ -401,7 +399,6 @@ class TestConvertFileToCmip7:
             "table_id": "Amon",
             "grid_label": "gn",
             "version": "v1",
-            "out_name": "tas",
             "branding_suffix": "tavg-h2m-hxy-u",
             "region": "glb",
         }
@@ -460,7 +457,6 @@ class TestConvertFileToCmip7:
             "table_id": "Amon",
             "grid_label": "gn",
             "version": "v1",
-            "out_name": "tas",
             "branding_suffix": "tavg-h2m-hxy-u",
             "region": "glb",
         }

--- a/packages/climate-ref-core/tests/unit/test_cmip6_to_cmip7.py
+++ b/packages/climate-ref-core/tests/unit/test_cmip6_to_cmip7.py
@@ -579,29 +579,6 @@ class TestCreateCmip7Filename:
 
         assert filename == "tas_tavg-h2m-hxy-u_mon_glb_gn_TestModel_piControl_r1i1p1f1.nc"
 
-    def test_out_name_used_over_variable_id(self):
-        """Test that out_name is used in filename instead of variable_id.
-
-        For variables like tasmax, the CMIP6 variable_id is 'tasmax' but the
-        CMIP7 out_name is 'tas'. The filename should use 'tas', not 'tasmax'.
-        """
-        attrs = {
-            "variable_id": "tasmax",
-            "out_name": "tas",
-            "branding_suffix": "tmaxavg-h2m-hxy-u",
-            "frequency": "mon",
-            "region": "glb",
-            "grid_label": "gn",
-            "source_id": "ACCESS-ESM1-5",
-            "experiment_id": "historical",
-            "variant_label": "r1i1p1f1",
-        }
-        filename = create_cmip7_filename(attrs)
-
-        assert filename == "tas_tmaxavg-h2m-hxy-u_mon_glb_gn_ACCESS-ESM1-5_historical_r1i1p1f1.nc"
-        # Confirm variable_id is NOT in filename (out_name is used instead)
-        assert "tasmax" not in filename
-
     def test_falls_back_to_variable_id_without_out_name(self):
         """Test that variable_id is used when out_name is absent."""
         attrs = {
@@ -640,14 +617,12 @@ class TestCreateCmip7FilenameFromConversion:
         }
         cmip7_attrs = convert_cmip6_to_cmip7_attrs(cmip6_attrs)
 
-        # variable_id stays as CMIP6 identity
-        assert cmip7_attrs["variable_id"] == "tasmax"
-        # out_name is the CMIP7 output name
-        assert cmip7_attrs["out_name"] == "tas"
-        # branded_variable uses out_name
+        # variable_id is updated
+        assert cmip7_attrs["variable_id"] == "tas"
+        # branded_variable uses updated variable_id
         assert cmip7_attrs["branded_variable"] == "tas_tmaxavg-h2m-hxy-u"
 
-        # Filename uses out_name, not variable_id
+        # Filename uses variable_id
         filename = create_cmip7_filename(cmip7_attrs)
         assert filename.startswith("tas_tmaxavg-h2m-hxy-u_")
         assert "tasmax" not in filename
@@ -667,7 +642,6 @@ class TestCreateCmip7FilenameFromConversion:
         cmip7_attrs = convert_cmip6_to_cmip7_attrs(cmip6_attrs)
 
         assert cmip7_attrs["variable_id"] == "tas"
-        assert cmip7_attrs["out_name"] == "tas"
         assert cmip7_attrs["branded_variable"] == "tas_tavg-h2m-hxy-u"
 
         filename = create_cmip7_filename(cmip7_attrs)
@@ -693,20 +667,19 @@ class TestDReqDrivenAttrsEdgeCases:
         }
         cmip7_attrs = convert_cmip6_to_cmip7_attrs(cmip6_attrs)
 
-        assert cmip7_attrs["variable_id"] == "tasmax"
-        assert cmip7_attrs["out_name"] == "tas"
+        assert cmip7_attrs["variable_id"] == "tas"
         assert cmip7_attrs["branded_variable"] == "tas_tmaxavg-h2m-hxy-u"
         assert cmip7_attrs["branding_suffix"] == "tmaxavg-h2m-hxy-u"
 
-        # Filename must use out_name, not variable_id
+        # Filename must use variable_id
         filename = create_cmip7_filename(cmip7_attrs)
         assert filename.startswith("tas_tmaxavg-h2m-hxy-u_")
         assert "tasmax" not in filename
 
-        # Path must use out_name, not variable_id
+        # Path must use variable_id
         path = create_cmip7_path(cmip7_attrs)
         path_parts = path.split("/")
-        # out_name component is at position 9 in the DRS path
+        # variable_id component is at position 9 in the DRS path
         assert "tas" in path_parts
         assert "tasmax" not in path_parts
 
@@ -722,8 +695,7 @@ class TestDReqDrivenAttrsEdgeCases:
         }
         cmip7_attrs = convert_cmip6_to_cmip7_attrs(cmip6_attrs)
 
-        assert cmip7_attrs["variable_id"] == "tasmin"
-        assert cmip7_attrs["out_name"] == "tas"
+        assert cmip7_attrs["variable_id"] == "tas"
         assert cmip7_attrs["branded_variable"] == "tas_tminavg-h2m-hxy-u"
 
     def test_imonant_tas_has_non_glb_region(self):

--- a/packages/climate-ref-core/tests/unit/test_constraints.py
+++ b/packages/climate-ref-core/tests/unit/test_constraints.py
@@ -48,6 +48,23 @@ class TestRequireFacets:
         expected_data = data if expected else empty
         assert_frame_equal(self.constraint.apply(data, empty), expected_data)
 
+    @pytest.mark.parametrize(
+        "data, expected",
+        [
+            (pd.DataFrame(columns=["variable_id", "path"]), False),
+            (pd.DataFrame({"variable_id": ["tas", "tos"], "path": ["tas.nc", "tos.nc"]}), True),
+        ],
+    )
+    def test_apply_any(self, data, expected):
+        constraint = RequireFacets(
+            dimension="variable_id",
+            required_facets=("tas", "pr"),
+            operator="any",
+        )
+        empty = data.loc[[]]
+        expected_data = data if expected else empty
+        assert_frame_equal(constraint.apply(data, empty), expected_data)
+
     def test_invalid_dimension(self):
         data = pd.DataFrame({"invalid": ["tas", "pr"], "path": ["tas.nc", "pr.nc"]})
         with pytest.raises(KeyError):


### PR DESCRIPTION
## Description

Replace "out_name" by "variable_id" in paths, as described in https://zenodo.org/records/17250297. Quoting the description of variable_id from the document:

> The variable_id in CMIP7 is also referred to as
"root name" and "out name". Usually all
variables associated with a particular
"standard name", as defined by the CF
conventions, are all assigned a single
variable_id, but sometimes the
branding_suffix cannot distinguish between
variables sharing the same standard_name, so
the variable_id may differ.

If I've understood it correctly, `out_name` is the name of the primary variable inside the file, while `variable_id` is the variable name used in the filename.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
