### PR TITLE
chore: add name to integration CI workflow

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -1,3 +1,5 @@
+name: CI Integration Tests
+
 # These tests run on self-hosted runners with access to a shared cache of datasets and software.
 # This allows us to run the full suite of tests,
 # including slow integration tests that require large datasets and/or long runtimes.


### PR DESCRIPTION
## Description

Add a top-level `name:` key to the integration CI workflow. Without it, GitHub Actions displays the file path (`.github/workflows/ci-integration.yaml`) as the workflow name in the UI.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

N/A - workflow config change only, no code/test/docs/changelog needed.