### PR TITLE
fix(test): isolate CLI tests from user database and xfail RLIMIT_AS on macOS

### DIFF
--- a/changelog/611.fix.md
+++ b/changelog/611.fix.md
@@ -1,0 +1,1 @@
+Fixed CLI test isolation by making the `invoke_cli` fixture depend on the `config` fixture, ensuring tests use an isolated database rather than the user's real one. Also marked `RLIMIT_AS` tests as expected failures on macOS where this resource limit is not supported.

--- a/packages/climate-ref/src/climate_ref/conftest_plugin.py
+++ b/packages/climate-ref/src/climate_ref/conftest_plugin.py
@@ -280,8 +280,13 @@ def config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, request: pytest.Fixt
 
 
 @pytest.fixture
-def invoke_cli(monkeypatch: pytest.MonkeyPatch) -> Callable[..., Result]:
-    """Invoke the REF CLI and verify exit code."""
+def invoke_cli(config: Config, monkeypatch: pytest.MonkeyPatch) -> Callable[..., Result]:
+    """Invoke the REF CLI and verify exit code.
+
+    Depends on the ``config`` fixture so every CLI invocation uses an
+    isolated configuration directory and database rather than the user's
+    real one.
+    """
     runner = CliRunner()
     # Older versions of typer mix stderr and stdout. This option has been removed in newer versions
     runner.mix_stderr = False  # type: ignore[attr-defined]

--- a/packages/climate-ref/tests/unit/executor/test_hpc_executor.py
+++ b/packages/climate-ref/tests/unit/executor/test_hpc_executor.py
@@ -1,6 +1,7 @@
 import os
 import re
 import resource
+import sys
 from unittest.mock import MagicMock, patch
 
 import parsl
@@ -193,6 +194,11 @@ class TestHPCExecutor:
             assert soft == expected_bytes
             assert hard >= expected_bytes
 
+    @pytest.mark.xfail(
+        sys.platform == "darwin",
+        reason="macOS does not support RLIMIT_AS",
+        raises=ValueError,
+    )
     def test_memory_limit_func(self):
         # Save original state
         os.environ.pop("MEMORY_LIMIT_PARSL_JOB_GB", None)
@@ -206,11 +212,11 @@ class TestHPCExecutor:
 
         unset_func()
         os.environ["MEMORY_LIMIT_PARSL_JOB_GB"] = "7"
+        expected_bytes = 7 * 1024 * 1024 * 1024
 
         @with_memory_limit(limit_from_env)
         def set_func():
             soft, hard = resource.getrlimit(resource.RLIMIT_AS)
-            expected_bytes = 7 * 1024 * 1024 * 1024
             assert soft == expected_bytes
             assert hard == -1 or hard >= expected_bytes
 


### PR DESCRIPTION
## Description

Fix 29 failing tests caused by two issues:

1. **CLI test isolation**: The `invoke_cli` fixture did not depend on the `config` fixture, so CLI tests hit the user's real database instead of an isolated temp one. If the user's database had a different alembic revision than the codebase (e.g. a removed migration), tests would fail with `Can't locate revision`. Fixed by making `invoke_cli` depend on `config`.

2. **macOS RLIMIT_AS**: `test_memory_limit_func` calls `resource.setrlimit(RLIMIT_AS)` which is not supported on macOS. Marked as `xfail` on Darwin.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`