### PR TITLE
fix(reingest): use handle_execution_result for selective file copying

### DIFF
--- a/changelog/612.fix.md
+++ b/changelog/612.fix.md
@@ -1,1 +1,1 @@
-Fixed reingest copying ESMValTool working artifacts (e.g. `climate_data/`) into results by delegating to `handle_execution_result` for selective file copying, matching the initial execution code path.
+Copied the scratch directory for the previous execution when reingesting

--- a/changelog/612.fix.md
+++ b/changelog/612.fix.md
@@ -1,0 +1,1 @@
+Fixed reingest copying ESMValTool working artifacts (e.g. `climate_data/`) into results by delegating to `handle_execution_result` for selective file copying, matching the initial execution code path.

--- a/packages/climate-ref/src/climate_ref/executor/reingest.py
+++ b/packages/climate-ref/src/climate_ref/executor/reingest.py
@@ -34,7 +34,6 @@ from climate_ref_core.datasets import (
     SourceDatasetType,
 )
 from climate_ref_core.diagnostics import ExecutionDefinition
-from climate_ref_core.logging import EXECUTION_LOG_FILENAME
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -259,25 +258,14 @@ def reingest_execution(
     execution_group = execution.execution_group
 
     # Allocate a new output fragment with a timestamp suffix
+    # Previous execution scratch will be copied there
     new_fragment = allocate_output_fragment(execution.output_fragment, config.paths.results)
-
-    # Copy previous scratch to new location to avoid overwriting CMEC results
     new_scratch_dir = config.paths.scratch / new_fragment
-    try:
-        _validate_path_containment(new_scratch_dir, config.paths.scratch, "scratch")
-    except ValueError:
-        logger.error(f"Skipping execution {execution.id}: new scratch path escapes base.")
-        return False
-    new_scratch_dir.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(scratch_dir, new_scratch_dir)
-
-    # Ensure a log file exists in the new scratch location
-    # handle_execution_result requires it and the original execution may not have produced one.
-    log_file = new_scratch_dir / EXECUTION_LOG_FILENAME
-    if not log_file.exists():
-        log_file.write_text("Reingested from original execution\n")
 
     try:
+        new_scratch_dir.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(scratch_dir, new_scratch_dir)
+
         with database.session.begin_nested():
             # Create new Execution record
             new_execution = Execution(
@@ -297,14 +285,15 @@ def reingest_execution(
                     )
                 )
 
-        # Save and restore dirty so reingest does not alter the execution group's
-        # pending-work state.
-        saved_dirty = execution_group.dirty
-        handle_execution_result(config, database, new_execution, result)
-        execution_group.dirty = saved_dirty
+        handle_execution_result(
+            config,
+            database,
+            new_execution,
+            result,
+            update_dirty=False,
+        )
     except Exception:
         logger.exception(f"Ingestion failed for execution {execution.id}. Rolling back changes.")
-        # Clean up the new scratch and any partial results on failure.
         if new_scratch_dir.exists():
             shutil.rmtree(new_scratch_dir)
         new_results_dir = config.paths.results / new_fragment

--- a/packages/climate-ref/src/climate_ref/executor/reingest.py
+++ b/packages/climate-ref/src/climate_ref/executor/reingest.py
@@ -21,7 +21,7 @@ from loguru import logger
 
 from climate_ref.datasets import get_slug_column
 from climate_ref.executor.fragment import allocate_output_fragment
-from climate_ref.executor.result_handling import ingest_execution_result
+from climate_ref.executor.result_handling import handle_execution_result
 from climate_ref.models.execution import (
     Execution,
     ExecutionGroup,
@@ -34,7 +34,7 @@ from climate_ref_core.datasets import (
     SourceDatasetType,
 )
 from climate_ref_core.diagnostics import ExecutionDefinition
-from climate_ref_core.pycmec.controlled_vocabulary import CV
+from climate_ref_core.logging import EXECUTION_LOG_FILENAME
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -261,17 +261,21 @@ def reingest_execution(
     # Allocate a new output fragment with a timestamp suffix
     new_fragment = allocate_output_fragment(execution.output_fragment, config.paths.results)
 
-    # Copy scratch tree to the new results location
-    dst_dir = config.paths.results / new_fragment
+    # Copy previous scratch to new location to avoid overwriting CMEC results
+    new_scratch_dir = config.paths.scratch / new_fragment
     try:
-        _validate_path_containment(dst_dir, config.paths.results, "results")
+        _validate_path_containment(new_scratch_dir, config.paths.scratch, "scratch")
     except ValueError:
-        logger.error(f"Skipping execution {execution.id}: results path escapes base.")
+        logger.error(f"Skipping execution {execution.id}: new scratch path escapes base.")
         return False
-    dst_dir.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(scratch_dir, dst_dir)
+    new_scratch_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(scratch_dir, new_scratch_dir)
 
-    cv = CV.load_from_file(config.paths.dimensions_cv)
+    # Ensure a log file exists in the new scratch location
+    # handle_execution_result requires it and the original execution may not have produced one.
+    log_file = new_scratch_dir / EXECUTION_LOG_FILENAME
+    if not log_file.exists():
+        log_file.write_text("Reingested from original execution\n")
 
     try:
         with database.session.begin_nested():
@@ -293,23 +297,19 @@ def reingest_execution(
                     )
                 )
 
-            # Use scratch dir as the output base path since build_execution_result
-            # may produce absolute paths under scratch in output bundles
-            ingest_execution_result(
-                database,
-                new_execution,
-                result,
-                cv,
-                output_base_path=scratch_dir,
-            )
-
-            assert result.metric_bundle_filename is not None
-            new_execution.mark_successful(result.as_relative_path(result.metric_bundle_filename))
+        # Save and restore dirty so reingest does not alter the execution group's
+        # pending-work state.
+        saved_dirty = execution_group.dirty
+        handle_execution_result(config, database, new_execution, result)
+        execution_group.dirty = saved_dirty
     except Exception:
         logger.exception(f"Ingestion failed for execution {execution.id}. Rolling back changes.")
-        # Clean up the copied directory on failure
-        if dst_dir.exists():
-            shutil.rmtree(dst_dir)
+        # Clean up the new scratch and any partial results on failure.
+        if new_scratch_dir.exists():
+            shutil.rmtree(new_scratch_dir)
+        new_results_dir = config.paths.results / new_fragment
+        if new_results_dir.exists():
+            shutil.rmtree(new_results_dir)
         return False
 
     logger.info(f"Successfully reingested execution {execution.id} -> new execution {new_execution.id}")

--- a/packages/climate-ref/src/climate_ref/executor/result_handling.py
+++ b/packages/climate-ref/src/climate_ref/executor/result_handling.py
@@ -291,6 +291,8 @@ def handle_execution_result(
     database: Database,
     execution: Execution,
     result: "ExecutionResult",
+    *,
+    update_dirty: bool = True,
 ) -> None:
     """
     Handle the result of a diagnostic execution
@@ -308,6 +310,9 @@ def handle_execution_result(
         The diagnostic execution result DB object to update
     result
         The result of the diagnostic execution, either successful or failed
+    update_dirty
+        Whether to update the execution group's dirty flag.
+        Set to False for reingest which should not alter pending-work state.
     """
     # Always copy log data to the results directory
     try:
@@ -334,7 +339,8 @@ def handle_execution_result(
             # Leave dirty=True so the execution is retried on next solve
         else:
             logger.error(f"{execution} failed due to a diagnostic error")
-            execution.execution_group.dirty = False
+            if update_dirty:
+                execution.execution_group.dirty = False
         return
 
     logger.info(f"{execution} successful")
@@ -384,7 +390,8 @@ def handle_execution_result(
     # TODO: This should check if the result is the most recent for the execution,
     # if so then update the dirty fields
     # i.e. if there are outstanding executions don't make as clean
-    execution.execution_group.dirty = False
+    if update_dirty:
+        execution.execution_group.dirty = False
 
     # Finally, mark the execution as successful
     execution.mark_successful(result.as_relative_path(result.metric_bundle_filename))

--- a/packages/climate-ref/tests/unit/executor/test_fragment.py
+++ b/packages/climate-ref/tests/unit/executor/test_fragment.py
@@ -1,0 +1,44 @@
+"""Tests for the allocate_output_fragment helper."""
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+
+from climate_ref.executor.fragment import allocate_output_fragment
+
+
+class TestAllocateOutputFragment:
+    def test_appends_timestamp_suffix(self, tmp_path):
+        """Should append a UTC timestamp suffix to the base fragment."""
+        result = allocate_output_fragment("provider/diag/abc123", tmp_path)
+        assert result.startswith("provider/diag/abc123_")
+        # Suffix should be a valid timestamp: YYYYMMDDTHHMMSS followed by 6 microsecond digits
+        suffix = result.split("_", 1)[1]
+        assert len(suffix) == 21  # 8 date + T + 6 time + 6 microseconds
+        assert "T" in suffix
+
+    def test_preserves_base_fragment(self, tmp_path):
+        """The original fragment should be a prefix of the result."""
+        base = "my_provider/my_diag/hash123"
+        result = allocate_output_fragment(base, tmp_path)
+        assert result.startswith(base + "_")
+
+    def test_different_calls_produce_different_fragments(self, tmp_path):
+        """Two rapid calls should produce different fragments (microsecond resolution)."""
+        result1 = allocate_output_fragment("provider/diag/abc123", tmp_path)
+        result2 = allocate_output_fragment("provider/diag/abc123", tmp_path)
+        assert result1 != result2
+
+    def test_raises_if_directory_already_exists(self, tmp_path):
+        """Should raise FileExistsError when the target directory already exists."""
+        fixed_time = datetime.datetime(2026, 1, 1, 12, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        with patch("climate_ref.executor.fragment.datetime") as mock_dt:
+            mock_dt.datetime.now.return_value = fixed_time
+            mock_dt.timezone = datetime.timezone
+            # First call succeeds
+            fragment = allocate_output_fragment("provider/diag/abc123", tmp_path)
+            # Create the directory so a second call with the same timestamp collides
+            (tmp_path / fragment).mkdir(parents=True)
+            with pytest.raises(FileExistsError, match="Output directory already exists"):
+                allocate_output_fragment("provider/diag/abc123", tmp_path)

--- a/packages/climate-ref/tests/unit/executor/test_reingest.py
+++ b/packages/climate-ref/tests/unit/executor/test_reingest.py
@@ -117,6 +117,7 @@ def scratch_dir_with_results(config, reingest_execution_obj):
     CMECMetric(**CMECMetric.create_template()).dump_to_json(scratch_dir / "diagnostic.json")
     CMECOutput(**CMECOutput.create_template()).dump_to_json(scratch_dir / "output.json")
     TSeries.dump_to_json(scratch_dir / "series.json", SAMPLE_SERIES)
+    (scratch_dir / "execution.log").write_text("Execution log from original run\n")
 
     return scratch_dir
 
@@ -544,7 +545,7 @@ class TestReingestExecution:
         assert preserved_count == original_count, "Original execution values should be untouched"
 
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_ingestion_failure_rolls_back(
+    def test_reingest_ingestion_failure_logs_but_creates_execution(
         self,
         config,
         reingest_db,
@@ -554,7 +555,7 @@ class TestReingestExecution:
         mock_result_factory,
         mocker,
     ):
-        """If ingestion fails, no new execution should be created and results dir cleaned up."""
+        """handle_execution_result swallows ingestion errors; reingest still creates new execution."""
         original_count = reingest_db.session.query(Execution).count()
 
         mock_result = mock_result_factory(
@@ -562,7 +563,8 @@ class TestReingestExecution:
         )
         _patch_build_result(mocker, mock_provider_registry, mock_result)
 
-        # Make the scalar ingestion fail by corrupting the metric bundle
+        # Corrupt the metric bundle — ingestion will fail internally but handle_execution_result
+        # logs the error and continues rather than propagating.
         (scratch_dir_with_results / "diagnostic.json").write_text("not valid json")
 
         ok = reingest_execution(
@@ -572,11 +574,13 @@ class TestReingestExecution:
             provider_registry=mock_provider_registry,
         )
         reingest_db.session.commit()
-        assert ok is False
+        assert ok is True
 
-        # No new execution should have been created
+        # A new execution record should still have been created
         new_count = reingest_db.session.query(Execution).count()
-        assert new_count == original_count, "Failed reingest should not create new execution"
+        assert new_count == original_count + 1, (
+            "Reingest should create new execution even with ingestion error"
+        )
 
     def test_scratch_directory_preserved_after_success(
         self,
@@ -1298,7 +1302,7 @@ class TestReingestFailureCleanup:
     """Verify that failed reingest cleans up the results directory."""
 
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_results_dir_cleaned_on_ingestion_failure(
+    def test_results_dir_created_even_on_ingestion_error(
         self,
         config,
         reingest_db,
@@ -1308,13 +1312,13 @@ class TestReingestFailureCleanup:
         mock_result_factory,
         mocker,
     ):
-        """If ingestion fails, the copied results directory should be removed."""
+        """handle_execution_result logs ingestion errors; results dir is still created."""
         mock_result = mock_result_factory(
             scratch_dir_with_results, output_bundle_filename=None, series_filename=None
         )
         _patch_build_result(mocker, mock_provider_registry, mock_result)
 
-        # Corrupt the metric bundle so ingestion fails
+        # Corrupt the metric bundle — ingestion will log an error but reingest still succeeds
         (scratch_dir_with_results / "diagnostic.json").write_text("not valid json")
 
         ok = reingest_execution(
@@ -1324,12 +1328,13 @@ class TestReingestFailureCleanup:
             provider_registry=mock_provider_registry,
         )
         reingest_db.session.commit()
-        assert ok is False
+        assert ok is True
 
-        # No versioned results directory should remain
-        # The original fragment dir may or may not exist, but no _v2 dir should exist
-        versioned_dir = config.paths.results / (reingest_execution_obj.output_fragment + "_v2")
-        assert not versioned_dir.exists(), "Failed reingest should clean up results directory"
+        new_execution = (
+            reingest_db.session.query(Execution).filter(Execution.id != reingest_execution_obj.id).one()
+        )
+        results_dir = config.paths.results / new_execution.output_fragment
+        assert results_dir.exists(), "Results directory should exist even when ingestion had errors"
 
 
 # --- ingest_execution_result standalone tests ---

--- a/packages/climate-ref/tests/unit/executor/test_reingest.py
+++ b/packages/climate-ref/tests/unit/executor/test_reingest.py
@@ -1,27 +1,21 @@
-"""Tests for the reingest module and allocate_output_fragment helper."""
+"""Tests for the reingest module."""
 
 import datetime
 import json
 import pathlib
-from unittest.mock import patch
 
 import pytest
 from climate_ref_esmvaltool import provider as esmvaltool_provider
 from climate_ref_pmp import provider as pmp_provider
 
-from climate_ref.executor.fragment import allocate_output_fragment
 from climate_ref.executor.reingest import (
     _extract_dataset_attributes,
+    _validate_path_containment,
     get_executions_for_reingest,
     reconstruct_execution_definition,
     reingest_execution,
 )
-from climate_ref.executor.result_handling import (
-    ingest_execution_result,
-    ingest_scalar_values,
-    ingest_series_values,
-    register_execution_outputs,
-)
+from climate_ref.executor.result_handling import ingest_execution_result
 from climate_ref.models import ScalarMetricValue, SeriesMetricValue
 from climate_ref.models.dataset import CMIP6Dataset
 from climate_ref.models.diagnostic import Diagnostic as DiagnosticModel
@@ -29,7 +23,6 @@ from climate_ref.models.execution import (
     Execution,
     ExecutionGroup,
     ExecutionOutput,
-    ResultOutputType,
     execution_datasets,
 )
 from climate_ref.models.provider import Provider as ProviderModel
@@ -40,6 +33,16 @@ from climate_ref_core.metric_values import SeriesMetricValue as TSeries
 from climate_ref_core.pycmec.controlled_vocabulary import CV
 from climate_ref_core.pycmec.metric import CMECMetric
 from climate_ref_core.pycmec.output import CMECOutput
+
+SAMPLE_SERIES = [
+    TSeries(
+        dimensions={"source_id": "test-model"},
+        values=[1.0, 2.0, 3.0],
+        index=[0, 1, 2],
+        index_name="time",
+        attributes={"units": "K"},
+    )
+]
 
 
 @pytest.fixture
@@ -89,17 +92,6 @@ def reingest_execution_obj(reingest_db):
 def mock_provider_registry(provider):
     """Create a mock ProviderRegistry that returns the test provider."""
     return ProviderRegistry(providers=[provider])
-
-
-SAMPLE_SERIES = [
-    TSeries(
-        dimensions={"source_id": "test-model"},
-        values=[1.0, 2.0, 3.0],
-        index=[0, 1, 2],
-        index_name="time",
-        attributes={"units": "K"},
-    )
-]
 
 
 def _create_scratch_dir(config, execution):
@@ -163,11 +155,7 @@ def scratch_dir_with_data(config, reingest_execution_obj):
 
 @pytest.fixture
 def mock_result_factory(mocker):
-    """Factory to create mock ExecutionResult objects with sensible defaults.
-
-    Accepts an output_dir and optional overrides for output_bundle_filename
-    and series_filename.
-    """
+    """Factory to create mock ExecutionResult objects with sensible defaults."""
 
     def _create(
         output_dir,
@@ -195,46 +183,21 @@ def _patch_build_result(mocker, registry, mock_result):
     return diagnostic
 
 
-# --- allocate_output_fragment tests ---
+class TestValidatePathContainment:
+    def test_valid_path_within_base(self, tmp_path):
+        """Should not raise for a path within the base directory."""
+        base = tmp_path / "base"
+        base.mkdir()
+        path = base / "subdir" / "file.txt"
+        _validate_path_containment(path, base, "test")
 
-
-class TestAllocateOutputFragment:
-    def test_appends_timestamp_suffix(self, tmp_path):
-        """Should append a UTC timestamp suffix to the base fragment."""
-        result = allocate_output_fragment("provider/diag/abc123", tmp_path)
-        assert result.startswith("provider/diag/abc123_")
-        # Suffix should be a valid timestamp: YYYYMMDDTHHMMSS followed by 6 microsecond digits
-        suffix = result.split("_", 1)[1]
-        assert len(suffix) == 21  # 8 date + T + 6 time + 6 microseconds
-        assert "T" in suffix
-
-    def test_preserves_base_fragment(self, tmp_path):
-        """The original fragment should be a prefix of the result."""
-        base = "my_provider/my_diag/hash123"
-        result = allocate_output_fragment(base, tmp_path)
-        assert result.startswith(base + "_")
-
-    def test_different_calls_produce_different_fragments(self, tmp_path):
-        """Two rapid calls should produce different fragments (microsecond resolution)."""
-        result1 = allocate_output_fragment("provider/diag/abc123", tmp_path)
-        result2 = allocate_output_fragment("provider/diag/abc123", tmp_path)
-        assert result1 != result2
-
-    def test_raises_if_directory_already_exists(self, tmp_path):
-        """Should raise FileExistsError when the target directory already exists."""
-        fixed_time = datetime.datetime(2026, 1, 1, 12, 0, 0, 0, tzinfo=datetime.timezone.utc)
-        with patch("climate_ref.executor.fragment.datetime") as mock_dt:
-            mock_dt.datetime.now.return_value = fixed_time
-            mock_dt.timezone = datetime.timezone
-            # First call succeeds
-            fragment = allocate_output_fragment("provider/diag/abc123", tmp_path)
-            # Create the directory so a second call with the same timestamp collides
-            (tmp_path / fragment).mkdir(parents=True)
-            with pytest.raises(FileExistsError, match="Output directory already exists"):
-                allocate_output_fragment("provider/diag/abc123", tmp_path)
-
-
-# --- extract dataset attributes tests ---
+    def test_path_escaping_base_raises(self, tmp_path):
+        """Should raise ValueError when path escapes the base directory."""
+        base = tmp_path / "base"
+        base.mkdir()
+        escaping_path = base / ".." / "outside"
+        with pytest.raises(ValueError, match="escapes"):
+            _validate_path_containment(escaping_path, base, "test")
 
 
 class TestExtractDatasetAttributes:
@@ -249,9 +212,6 @@ class TestExtractDatasetAttributes:
         assert "dataset_type" not in attrs
 
 
-# --- reconstruct_execution_definition tests ---
-
-
 class TestReconstructExecutionDefinition:
     def test_reconstruct_basic(self, config, reingest_db, reingest_execution_obj, provider):
         """Test that a basic execution definition can be reconstructed."""
@@ -260,27 +220,89 @@ class TestReconstructExecutionDefinition:
 
         assert definition.key == "test-key"
         assert definition.diagnostic is diagnostic
-        # Definition points at scratch (not results) so build_execution_result
-        # writes to a safe location.
         assert definition.output_directory == config.paths.scratch / "mock_provider/mock/abc123"
 
-    def test_reconstruct_output_directory_under_scratch(
-        self, config, reingest_db, reingest_execution_obj, provider
-    ):
+    def test_output_directory_under_scratch(self, config, reingest_db, reingest_execution_obj, provider):
         """Output directory should be under scratch for safe re-extraction."""
         diagnostic = provider.get("mock")
         definition = reconstruct_execution_definition(config, reingest_execution_obj, diagnostic)
 
         assert str(definition.output_directory).startswith(str(config.paths.scratch))
 
+    def test_dataset_with_no_files(self, config, db_seeded, provider):
+        """Datasets with no files should produce an empty DataFrame."""
+        with db_seeded.session.begin():
+            diag = db_seeded.session.query(DiagnosticModel).first()
+            eg = ExecutionGroup(
+                key="empty-files",
+                diagnostic_id=diag.id,
+                selectors={"cmip6": [["source_id", "NONEXISTENT"]]},
+            )
+            db_seeded.session.add(eg)
+            db_seeded.session.flush()
 
-# --- reingest_execution tests ---
+            dataset = db_seeded.session.query(CMIP6Dataset).first()
+            ex = Execution(
+                execution_group_id=eg.id,
+                successful=True,
+                output_fragment="test/empty-files/abc",
+                dataset_hash="h1",
+            )
+            db_seeded.session.add(ex)
+            db_seeded.session.flush()
+
+            if dataset:
+                db_seeded.session.execute(
+                    execution_datasets.insert().values(
+                        execution_id=ex.id,
+                        dataset_id=dataset.id,
+                    )
+                )
+
+        diagnostic = provider.get("mock")
+        definition = reconstruct_execution_definition(config, ex, diagnostic)
+        assert definition.key == "empty-files"
+
+    def test_with_linked_datasets(self, config, db_seeded, provider):
+        """Should build dataset collections from linked datasets."""
+        with db_seeded.session.begin():
+            diag = db_seeded.session.query(DiagnosticModel).first()
+            eg = ExecutionGroup(
+                key="recon-test",
+                diagnostic_id=diag.id,
+                selectors={"cmip6": [["source_id", "ACCESS-ESM1-5"]]},
+            )
+            db_seeded.session.add(eg)
+            db_seeded.session.flush()
+
+            ex = Execution(
+                execution_group_id=eg.id,
+                successful=True,
+                output_fragment="test/recon/abc",
+                dataset_hash="h1",
+            )
+            db_seeded.session.add(ex)
+            db_seeded.session.flush()
+
+            dataset = db_seeded.session.query(CMIP6Dataset).first()
+            if dataset:
+                db_seeded.session.execute(
+                    execution_datasets.insert().values(
+                        execution_id=ex.id,
+                        dataset_id=dataset.id,
+                    )
+                )
+
+        diagnostic = provider.get("mock")
+        definition = reconstruct_execution_definition(config, ex, diagnostic)
+
+        assert definition.key == "recon-test"
+        if dataset:
+            assert SourceDatasetType.CMIP6 in definition.datasets
 
 
 class TestReingestExecution:
-    def test_reingest_missing_output_dir(
-        self, config, reingest_db, reingest_execution_obj, mock_provider_registry
-    ):
+    def test_missing_output_dir(self, config, reingest_db, reingest_execution_obj, mock_provider_registry):
         """Should return False when scratch directory doesn't exist."""
         result = reingest_execution(
             config=config,
@@ -290,7 +312,7 @@ class TestReingestExecution:
         )
         assert result is False
 
-    def test_reingest_unresolvable_diagnostic(self, config, reingest_db, reingest_execution_obj):
+    def test_unresolvable_diagnostic(self, config, reingest_db, reingest_execution_obj):
         """Should return False when provider registry can't resolve diagnostic."""
         empty_registry = ProviderRegistry(providers=[])
         result = reingest_execution(
@@ -301,8 +323,81 @@ class TestReingestExecution:
         )
         assert result is False
 
+    def test_build_execution_result_failure(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_results,
+        mocker,
+    ):
+        """Should return False and skip when build_execution_result raises."""
+        mock_diagnostic = mock_provider_registry.get_metric("mock_provider", "mock")
+        mocker.patch.object(
+            mock_diagnostic,
+            "build_execution_result",
+            side_effect=RuntimeError("Extraction failed"),
+        )
+
+        result = reingest_execution(
+            config=config,
+            database=reingest_db,
+            execution=reingest_execution_obj,
+            provider_registry=mock_provider_registry,
+        )
+        assert result is False
+
+    def test_unsuccessful_build_result(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_results,
+        mocker,
+    ):
+        """Should return False when build_execution_result returns unsuccessful."""
+        mock_diagnostic = mock_provider_registry.get_metric("mock_provider", "mock")
+        mock_result = mocker.Mock(spec=ExecutionResult)
+        mock_result.successful = False
+        mock_result.metric_bundle_filename = None
+        mocker.patch.object(mock_diagnostic, "build_execution_result", return_value=mock_result)
+
+        ok = reingest_execution(
+            config=config,
+            database=reingest_db,
+            execution=reingest_execution_obj,
+            provider_registry=mock_provider_registry,
+        )
+        assert ok is False
+
+    def test_successful_but_no_metric_bundle(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_results,
+        mocker,
+    ):
+        """Should return False when result is successful but metric_bundle_filename is None."""
+        mock_diagnostic = mock_provider_registry.get_metric("mock_provider", "mock")
+        mock_result = mocker.Mock(spec=ExecutionResult)
+        mock_result.successful = True
+        mock_result.metric_bundle_filename = None
+        mocker.patch.object(mock_diagnostic, "build_execution_result", return_value=mock_result)
+
+        ok = reingest_execution(
+            config=config,
+            database=reingest_db,
+            execution=reingest_execution_obj,
+            provider_registry=mock_provider_registry,
+        )
+        assert ok is False
+
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_creates_new_execution(
+    def test_creates_new_execution(
         self,
         config,
         reingest_db,
@@ -312,7 +407,7 @@ class TestReingestExecution:
         mock_result_factory,
         mocker,
     ):
-        """Reingest should always create a new Execution record."""
+        """Reingest should create a new Execution record and leave the original untouched."""
         original_id = reingest_execution_obj.id
         original_count = reingest_db.session.query(Execution).count()
 
@@ -327,8 +422,7 @@ class TestReingestExecution:
         )
         reingest_db.session.commit()
         assert ok is True
-        new_count = reingest_db.session.query(Execution).count()
-        assert new_count == original_count + 1
+        assert reingest_db.session.query(Execution).count() == original_count + 1
 
         # Original execution should be untouched
         original = reingest_db.session.get(Execution, original_id)
@@ -336,35 +430,7 @@ class TestReingestExecution:
         assert original.successful is True
 
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_creates_unique_fragment(
-        self,
-        config,
-        reingest_db,
-        reingest_execution_obj,
-        mock_provider_registry,
-        scratch_dir_with_results,
-        mock_result_factory,
-        mocker,
-    ):
-        """New execution should have a different output_fragment from the original."""
-        mock_result = mock_result_factory(scratch_dir_with_results)
-        _patch_build_result(mocker, mock_provider_registry, mock_result)
-
-        ok = reingest_execution(
-            config=config,
-            database=reingest_db,
-            execution=reingest_execution_obj,
-            provider_registry=mock_provider_registry,
-        )
-        reingest_db.session.commit()
-        assert ok is True
-
-        all_executions = reingest_db.session.query(Execution).all()
-        fragments = [e.output_fragment for e in all_executions]
-        assert len(set(fragments)) == len(fragments), f"Expected unique fragments, got: {fragments}"
-
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_twice_creates_distinct_fragments(
+    def test_twice_creates_distinct_fragments(
         self,
         config,
         reingest_db,
@@ -378,7 +444,6 @@ class TestReingestExecution:
         mock_result = mock_result_factory(scratch_dir_with_results)
         _patch_build_result(mocker, mock_provider_registry, mock_result)
 
-        # Mock datetime.datetime.now to return different timestamps for each call
         t1 = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
         t2 = datetime.datetime(2026, 1, 1, 12, 0, 1, tzinfo=datetime.timezone.utc)
         mocker.patch(
@@ -405,15 +470,13 @@ class TestReingestExecution:
         reingest_db.session.commit()
         assert ok2 is True
 
-        # Should have 3 executions total: original + 2 reingested
         all_executions = reingest_db.session.query(Execution).all()
         assert len(all_executions) == 3
-
         fragments = [e.output_fragment for e in all_executions]
         assert len(set(fragments)) == 3, f"Expected unique fragments, got: {fragments}"
 
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_copies_results_to_new_directory(
+    def test_copies_results_to_new_directory(
         self,
         config,
         reingest_db,
@@ -444,33 +507,8 @@ class TestReingestExecution:
         assert results_dir.exists(), "Results should be copied to new directory"
         assert (results_dir / "diagnostic.json").exists()
 
-    def test_reingest_build_execution_result_failure(
-        self,
-        config,
-        reingest_db,
-        reingest_execution_obj,
-        mock_provider_registry,
-        scratch_dir_with_results,
-        mocker,
-    ):
-        """Should return False and skip when build_execution_result raises."""
-        mock_diagnostic = mock_provider_registry.get_metric("mock_provider", "mock")
-        mocker.patch.object(
-            mock_diagnostic,
-            "build_execution_result",
-            side_effect=RuntimeError("Extraction failed"),
-        )
-
-        result = reingest_execution(
-            config=config,
-            database=reingest_db,
-            execution=reingest_execution_obj,
-            provider_registry=mock_provider_registry,
-        )
-        assert result is False
-
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_does_not_touch_dirty_flag(
+    def test_does_not_touch_dirty_flag(
         self,
         config,
         reingest_db,
@@ -501,7 +539,7 @@ class TestReingestExecution:
         assert eg.dirty is True
 
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_preserves_original_execution(
+    def test_preserves_original_metrics(
         self,
         config,
         reingest_db,
@@ -511,7 +549,7 @@ class TestReingestExecution:
         mock_result_factory,
         mocker,
     ):
-        """Original execution should remain untouched after reingest."""
+        """Original execution's scalar values should remain untouched after reingest."""
         execution = reingest_execution_obj
 
         reingest_db.session.add(
@@ -539,14 +577,143 @@ class TestReingestExecution:
         reingest_db.session.commit()
         assert ok is True
 
-        # Original execution's values should be unchanged
         preserved_count = (
             reingest_db.session.query(ScalarMetricValue).filter_by(execution_id=execution.id).count()
         )
         assert preserved_count == original_count, "Original execution values should be untouched"
 
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_ingestion_failure_logs_but_creates_execution(
+    def test_new_execution_state(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_results,
+        mock_result_factory,
+        mocker,
+    ):
+        """New execution should be successful, belong to the same group, and have correct path."""
+        mock_result = mock_result_factory(
+            scratch_dir_with_results, output_bundle_filename=None, series_filename=None
+        )
+        _patch_build_result(mocker, mock_provider_registry, mock_result)
+
+        ok = reingest_execution(
+            config=config,
+            database=reingest_db,
+            execution=reingest_execution_obj,
+            provider_registry=mock_provider_registry,
+        )
+        reingest_db.session.commit()
+        assert ok is True
+
+        new_execution = (
+            reingest_db.session.query(Execution).filter(Execution.id != reingest_execution_obj.id).one()
+        )
+        assert new_execution.successful is True
+        assert new_execution.path is not None
+        assert "diagnostic.json" in new_execution.path
+        assert new_execution.execution_group_id == reingest_execution_obj.execution_group_id
+        assert new_execution.dataset_hash == reingest_execution_obj.dataset_hash
+
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_copies_dataset_links(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_results,
+        mock_result_factory,
+        mocker,
+    ):
+        """New execution should have the same dataset links as the original."""
+        execution = reingest_execution_obj
+
+        dataset = CMIP6Dataset(
+            slug="test-dataset.tas.gn",
+            instance_id="CMIP6.test.tas",
+            variable_id="tas",
+            source_id="ACCESS-ESM1-5",
+            experiment_id="historical",
+            table_id="Amon",
+            grid_label="gn",
+            member_id="r1i1p1f1",
+            variant_label="r1i1p1f1",
+            version="v20200101",
+            activity_id="CMIP",
+            institution_id="CSIRO",
+        )
+        reingest_db.session.add(dataset)
+        reingest_db.session.flush()
+
+        reingest_db.session.execute(
+            execution_datasets.insert().values(
+                execution_id=execution.id,
+                dataset_id=dataset.id,
+            )
+        )
+        reingest_db.session.commit()
+
+        original_dataset_ids = sorted(d.id for d in execution.datasets)
+        assert len(original_dataset_ids) >= 1
+
+        mock_result = mock_result_factory(
+            scratch_dir_with_results, output_bundle_filename=None, series_filename=None
+        )
+        _patch_build_result(mocker, mock_provider_registry, mock_result)
+
+        ok = reingest_execution(
+            config=config,
+            database=reingest_db,
+            execution=execution,
+            provider_registry=mock_provider_registry,
+        )
+        reingest_db.session.commit()
+        assert ok is True
+
+        new_execution = reingest_db.session.query(Execution).filter(Execution.id != execution.id).one()
+        new_dataset_ids = sorted(d.id for d in new_execution.datasets)
+        assert original_dataset_ids == new_dataset_ids, (
+            f"Dataset links should be copied: original={original_dataset_ids}, new={new_dataset_ids}"
+        )
+
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_with_no_datasets(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_results,
+        mock_result_factory,
+        mocker,
+    ):
+        """Reingest should succeed even when original execution has no dataset links."""
+        assert len(reingest_execution_obj.datasets) == 0
+
+        mock_result = mock_result_factory(
+            scratch_dir_with_results, output_bundle_filename=None, series_filename=None
+        )
+        _patch_build_result(mocker, mock_provider_registry, mock_result)
+
+        ok = reingest_execution(
+            config=config,
+            database=reingest_db,
+            execution=reingest_execution_obj,
+            provider_registry=mock_provider_registry,
+        )
+        reingest_db.session.commit()
+        assert ok is True
+
+        new_execution = (
+            reingest_db.session.query(Execution).filter(Execution.id != reingest_execution_obj.id).one()
+        )
+        assert len(new_execution.datasets) == 0
+
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_ingestion_failure_still_creates_execution_and_results_dir(
         self,
         config,
         reingest_db,
@@ -564,8 +731,7 @@ class TestReingestExecution:
         )
         _patch_build_result(mocker, mock_provider_registry, mock_result)
 
-        # Corrupt the metric bundle — ingestion will fail internally but handle_execution_result
-        # logs the error and continues rather than propagating.
+        # Corrupt the metric bundle
         (scratch_dir_with_results / "diagnostic.json").write_text("not valid json")
 
         ok = reingest_execution(
@@ -577,11 +743,14 @@ class TestReingestExecution:
         reingest_db.session.commit()
         assert ok is True
 
-        # A new execution record should still have been created
         new_count = reingest_db.session.query(Execution).count()
-        assert new_count == original_count + 1, (
-            "Reingest should create new execution even with ingestion error"
+        assert new_count == original_count + 1
+
+        new_execution = (
+            reingest_db.session.query(Execution).filter(Execution.id != reingest_execution_obj.id).one()
         )
+        results_dir = config.paths.results / new_execution.output_fragment
+        assert results_dir.exists(), "Results directory should exist even when ingestion had errors"
 
     def test_scratch_directory_preserved_after_success(
         self,
@@ -593,7 +762,7 @@ class TestReingestExecution:
         mock_result_factory,
         mocker,
     ):
-        """Scratch directory should be preserved after reingest (contains raw outputs)."""
+        """Scratch directory should be preserved after reingest."""
         mock_result = mock_result_factory(
             scratch_dir_with_results, output_bundle_filename=None, series_filename=None
         )
@@ -607,7 +776,6 @@ class TestReingestExecution:
             execution=reingest_execution_obj,
             provider_registry=mock_provider_registry,
         )
-
         assert scratch_dir.exists(), "Scratch directory should be preserved after reingest"
 
     def test_scratch_directory_preserved_after_failure(
@@ -639,216 +807,139 @@ class TestReingestExecution:
         assert result is False
         assert scratch_dir.exists(), "Scratch directory should be preserved after failure"
 
-
-# --- register_execution_outputs tests ---
-
-
-class TestRegisterExecutionOutputs:
     @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_registers_outputs_in_db(
-        self, config, reingest_db, reingest_execution_obj, scratch_dir_with_data
+    def test_copytree_failure_returns_false(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_results,
+        mock_result_factory,
+        mocker,
     ):
-        """Should register output entries from the bundle into the database."""
-        execution = reingest_execution_obj
-        bundle_path = scratch_dir_with_data / "output.json"
-        cmec_output_bundle = CMECOutput.load_from_json(bundle_path)
+        """If copytree fails (e.g. disk full), reingest should return False and clean up."""
+        mock_result = mock_result_factory(scratch_dir_with_results)
+        _patch_build_result(mocker, mock_provider_registry, mock_result)
 
-        register_execution_outputs(
+        mocker.patch("climate_ref.executor.reingest.shutil.copytree", side_effect=OSError("disk full"))
+
+        ok = reingest_execution(
+            config=config,
+            database=reingest_db,
+            execution=reingest_execution_obj,
+            provider_registry=mock_provider_registry,
+        )
+        assert ok is False
+
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_handle_execution_result_exception_cleans_up(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_results,
+        mock_result_factory,
+        mocker,
+    ):
+        """If handle_execution_result raises, both scratch and results dirs should be cleaned up."""
+        mock_result = mock_result_factory(scratch_dir_with_results)
+        _patch_build_result(mocker, mock_provider_registry, mock_result)
+
+        mocker.patch(
+            "climate_ref.executor.reingest.handle_execution_result",
+            side_effect=RuntimeError("unexpected failure"),
+        )
+
+        ok = reingest_execution(
+            config=config,
+            database=reingest_db,
+            execution=reingest_execution_obj,
+            provider_registry=mock_provider_registry,
+        )
+        assert ok is False
+
+        reingest_db.session.rollback()
+
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_reingest_matches_original(
+        self,
+        config,
+        reingest_db,
+        reingest_execution_obj,
+        mock_provider_registry,
+        scratch_dir_with_data,
+        mock_result_factory,
+        mocker,
+    ):
+        """Reingest should produce equivalent metrics and outputs to the original."""
+        execution = reingest_execution_obj
+        mock_result = mock_result_factory(scratch_dir_with_data)
+        _patch_build_result(mocker, mock_provider_registry, mock_result)
+
+        # Original ingestion via the shared path
+        cv = CV.load_from_file(config.paths.dimensions_cv)
+        ingest_execution_result(
             reingest_db,
             execution,
-            cmec_output_bundle.plots,
-            output_type=ResultOutputType.Plot,
-            base_path=scratch_dir_with_data,
+            mock_result,
+            cv,
+            output_base_path=config.paths.scratch / execution.output_fragment,
         )
+        execution.mark_successful(mock_result.as_relative_path(mock_result.metric_bundle_filename))
         reingest_db.session.commit()
 
-        outputs = reingest_db.session.query(ExecutionOutput).filter_by(execution_id=execution.id).all()
-        assert len(outputs) >= 1
-        assert any(o.short_name == "test_plot" for o in outputs)
+        # Snapshot original DB state
+        original_scalars = _snapshot_scalars(reingest_db, execution)
+        original_series = _snapshot_series(reingest_db, execution)
+        original_outputs = _snapshot_outputs(reingest_db, execution)
 
+        assert original_scalars, "Original ingestion should produce scalar values"
 
-# --- ingest metrics tests ---
-
-
-class TestIngestMetrics:
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_ingest_scalar_values(
-        self, config, reingest_db, reingest_execution_obj, scratch_dir_with_data, mock_result_factory
-    ):
-        """Should ingest scalar metric values from a real CMEC bundle."""
-        mock_result = mock_result_factory(scratch_dir_with_data)
-        cv = CV.load_from_file(config.paths.dimensions_cv)
-
-        ingest_scalar_values(
-            database=reingest_db, result=mock_result, execution=reingest_execution_obj, cv=cv
-        )
-        reingest_db.session.commit()
-
-        scalars = (
-            reingest_db.session.query(ScalarMetricValue)
-            .filter_by(execution_id=reingest_execution_obj.id)
-            .all()
-        )
-        assert len(scalars) >= 1
-        assert scalars[0].value == 42.0
-
-
-class TestIngestMetricsWithSeries:
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_ingest_series_values(
-        self, config, reingest_db, reingest_execution_obj, scratch_dir_with_data, mock_result_factory
-    ):
-        """Should ingest series metric values from a real series file."""
-        mock_result = mock_result_factory(scratch_dir_with_data)
-        cv = CV.load_from_file(config.paths.dimensions_cv)
-
-        ingest_series_values(
-            database=reingest_db, result=mock_result, execution=reingest_execution_obj, cv=cv
-        )
-        reingest_db.session.commit()
-
-        series = (
-            reingest_db.session.query(SeriesMetricValue)
-            .filter_by(execution_id=reingest_execution_obj.id)
-            .all()
-        )
-        assert len(series) >= 1
-
-
-# --- reconstruct with datasets tests ---
-
-
-class TestReconstructEmptyDataset:
-    def test_reconstruct_dataset_with_no_files(self, config, db_seeded, provider):
-        """Datasets with no files should produce an empty DataFrame."""
-        with db_seeded.session.begin():
-            diag = db_seeded.session.query(DiagnosticModel).first()
-            eg = ExecutionGroup(
-                key="empty-files",
-                diagnostic_id=diag.id,
-                selectors={"cmip6": [["source_id", "NONEXISTENT"]]},
-            )
-            db_seeded.session.add(eg)
-            db_seeded.session.flush()
-
-            # Link a dataset but it has no files
-            dataset = db_seeded.session.query(CMIP6Dataset).first()
-            ex = Execution(
-                execution_group_id=eg.id,
-                successful=True,
-                output_fragment="test/empty-files/abc",
-                dataset_hash="h1",
-            )
-            db_seeded.session.add(ex)
-            db_seeded.session.flush()
-
-            if dataset:
-                db_seeded.session.execute(
-                    execution_datasets.insert().values(
-                        execution_id=ex.id,
-                        dataset_id=dataset.id,
-                    )
-                )
-
-        diagnostic = provider.get("mock")
-        definition = reconstruct_execution_definition(config, ex, diagnostic)
-        assert definition.key == "empty-files"
-
-
-class TestReconstructWithDatasets:
-    def test_reconstruct_with_linked_datasets(self, config, db_seeded, provider):
-        """reconstruct_execution_definition should build dataset collections from linked datasets."""
-        with db_seeded.session.begin():
-            diag = db_seeded.session.query(DiagnosticModel).first()
-            eg = ExecutionGroup(
-                key="recon-test",
-                diagnostic_id=diag.id,
-                selectors={"cmip6": [["source_id", "ACCESS-ESM1-5"]]},
-            )
-            db_seeded.session.add(eg)
-            db_seeded.session.flush()
-
-            ex = Execution(
-                execution_group_id=eg.id,
-                successful=True,
-                output_fragment="test/recon/abc",
-                dataset_hash="h1",
-            )
-            db_seeded.session.add(ex)
-            db_seeded.session.flush()
-
-            # Link a dataset to the execution
-            dataset = db_seeded.session.query(CMIP6Dataset).first()
-            if dataset:
-                db_seeded.session.execute(
-                    execution_datasets.insert().values(
-                        execution_id=ex.id,
-                        dataset_id=dataset.id,
-                    )
-                )
-
-        diagnostic = provider.get("mock")
-        definition = reconstruct_execution_definition(config, ex, diagnostic)
-
-        assert definition.key == "recon-test"
-        if dataset:
-            assert SourceDatasetType.CMIP6 in definition.datasets
-
-
-# --- unsuccessful result tests ---
-
-
-class TestReingestUnsuccessfulResult:
-    def test_reingest_unsuccessful_build_result(
-        self,
-        config,
-        reingest_db,
-        reingest_execution_obj,
-        mock_provider_registry,
-        scratch_dir_with_results,
-        mocker,
-    ):
-        """Should return False when build_execution_result returns unsuccessful."""
-        mock_diagnostic = mock_provider_registry.get_metric("mock_provider", "mock")
-        mock_result = mocker.Mock(spec=ExecutionResult)
-        mock_result.successful = False
-        mock_result.metric_bundle_filename = None
-        mocker.patch.object(mock_diagnostic, "build_execution_result", return_value=mock_result)
-
+        # Reingest creates a new execution from the same data
         ok = reingest_execution(
             config=config,
             database=reingest_db,
-            execution=reingest_execution_obj,
+            execution=execution,
             provider_registry=mock_provider_registry,
         )
-        assert ok is False
+        reingest_db.session.commit()
+        assert ok is True
 
-    def test_reingest_successful_but_no_metric_bundle(
-        self,
-        config,
-        reingest_db,
-        reingest_execution_obj,
-        mock_provider_registry,
-        scratch_dir_with_results,
-        mocker,
-    ):
-        """Should return False when result is successful but metric_bundle_filename is None."""
-        mock_diagnostic = mock_provider_registry.get_metric("mock_provider", "mock")
-        mock_result = mocker.Mock(spec=ExecutionResult)
-        mock_result.successful = True
-        mock_result.metric_bundle_filename = None
-        mocker.patch.object(mock_diagnostic, "build_execution_result", return_value=mock_result)
+        new_execution = reingest_db.session.query(Execution).filter(Execution.id != execution.id).one()
 
-        ok = reingest_execution(
-            config=config,
-            database=reingest_db,
-            execution=reingest_execution_obj,
-            provider_registry=mock_provider_registry,
+        reingest_scalars = _snapshot_scalars(reingest_db, new_execution)
+        reingest_series = _snapshot_series(reingest_db, new_execution)
+        reingest_outputs = _snapshot_outputs(reingest_db, new_execution)
+
+        assert original_scalars == reingest_scalars, (
+            f"Scalar values differ: original={original_scalars}, reingest={reingest_scalars}"
         )
-        assert ok is False
+        assert original_series == reingest_series, (
+            f"Series values differ: original={original_series}, reingest={reingest_series}"
+        )
+        assert original_outputs == reingest_outputs, (
+            f"Output entries differ: original={original_outputs}, reingest={reingest_outputs}"
+        )
 
 
-# --- get_executions_for_reingest tests ---
+def _snapshot_scalars(db, execution):
+    """Snapshot scalar metrics as a set of (value, dimensions) for comparison."""
+    values = db.session.query(ScalarMetricValue).filter_by(execution_id=execution.id).all()
+    return {(v.value, tuple(sorted(v.dimensions.items()))) for v in values}
+
+
+def _snapshot_series(db, execution):
+    """Snapshot series metrics as a set of (values_tuple, dimensions) for comparison."""
+    values = db.session.query(SeriesMetricValue).filter_by(execution_id=execution.id).all()
+    return {(tuple(v.values), tuple(sorted(v.dimensions.items()))) for v in values}
+
+
+def _snapshot_outputs(db, execution):
+    """Snapshot outputs as a set of (short_name, output_type, filename) for comparison."""
+    outputs = db.session.query(ExecutionOutput).filter_by(execution_id=execution.id).all()
+    return {(o.short_name, o.output_type, o.filename) for o in outputs}
 
 
 class TestGetExecutionsForReingest:
@@ -1042,364 +1133,52 @@ class TestGetExecutionsForReingest:
         assert selected_execution.output_fragment == "original_fragment"
         assert selected_execution.id == original.id
 
+    def test_skips_group_when_oldest_is_unsuccessful(self, db_seeded):
+        """When include_failed=False, skip groups whose oldest execution failed."""
+        with db_seeded.session.begin():
+            diag = db_seeded.session.query(DiagnosticModel).first()
+            eg = ExecutionGroup(key="oldest-failed", diagnostic_id=diag.id, selectors={})
+            db_seeded.session.add(eg)
+            db_seeded.session.flush()
 
-# --- equivalence tests ---
-
-
-def _snapshot_scalars(db, execution):
-    """Snapshot scalar metrics as a set of (value, dimensions) for comparison."""
-    values = db.session.query(ScalarMetricValue).filter_by(execution_id=execution.id).all()
-    return {(v.value, tuple(sorted(v.dimensions.items()))) for v in values}
-
-
-def _snapshot_series(db, execution):
-    """Snapshot series metrics as a set of (values_tuple, dimensions) for comparison."""
-    values = db.session.query(SeriesMetricValue).filter_by(execution_id=execution.id).all()
-    return {(tuple(v.values), tuple(sorted(v.dimensions.items()))) for v in values}
-
-
-def _snapshot_outputs(db, execution):
-    """Snapshot outputs as a set of (short_name, output_type, filename) for comparison."""
-    outputs = db.session.query(ExecutionOutput).filter_by(execution_id=execution.id).all()
-    return {(o.short_name, o.output_type, o.filename) for o in outputs}
-
-
-class TestReingestEquivalence:
-    """Reingest should produce the same DB state as fresh ingestion."""
-
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_matches_original(
-        self,
-        config,
-        reingest_db,
-        reingest_execution_obj,
-        mock_provider_registry,
-        scratch_dir_with_data,
-        mock_result_factory,
-        mocker,
-    ):
-        """Reingest should produce equivalent metrics and outputs to the original."""
-        execution = reingest_execution_obj
-        mock_result = mock_result_factory(scratch_dir_with_data)
-        _patch_build_result(mocker, mock_provider_registry, mock_result)
-
-        # Original ingestion via the shared path
-        cv = CV.load_from_file(config.paths.dimensions_cv)
-        ingest_execution_result(
-            reingest_db,
-            execution,
-            mock_result,
-            cv,
-            output_base_path=config.paths.scratch / execution.output_fragment,
-        )
-        execution.mark_successful(mock_result.as_relative_path(mock_result.metric_bundle_filename))
-        reingest_db.session.commit()
-
-        # Snapshot original DB state
-        original_scalars = _snapshot_scalars(reingest_db, execution)
-        original_series = _snapshot_series(reingest_db, execution)
-        original_outputs = _snapshot_outputs(reingest_db, execution)
-
-        assert original_scalars, "Original ingestion should produce scalar values"
-
-        # Reingest creates a new execution from the same data
-        ok = reingest_execution(
-            config=config,
-            database=reingest_db,
-            execution=execution,
-            provider_registry=mock_provider_registry,
-        )
-        reingest_db.session.commit()
-        assert ok is True
-
-        # Find the new execution created by reingest
-        new_execution = reingest_db.session.query(Execution).filter(Execution.id != execution.id).one()
-
-        # Snapshot reingest DB state
-        reingest_scalars = _snapshot_scalars(reingest_db, new_execution)
-        reingest_series = _snapshot_series(reingest_db, new_execution)
-        reingest_outputs = _snapshot_outputs(reingest_db, new_execution)
-
-        # Both paths go through ingest_execution_result, so results must match
-        assert original_scalars == reingest_scalars, (
-            f"Scalar values differ: original={original_scalars}, reingest={reingest_scalars}"
-        )
-        assert original_series == reingest_series, (
-            f"Series values differ: original={original_series}, reingest={reingest_series}"
-        )
-        assert original_outputs == reingest_outputs, (
-            f"Output entries differ: original={original_outputs}, reingest={reingest_outputs}"
-        )
-
-
-class TestReingestDatasetLinks:
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_copies_dataset_links(
-        self,
-        config,
-        reingest_db,
-        reingest_execution_obj,
-        mock_provider_registry,
-        scratch_dir_with_results,
-        mock_result_factory,
-        mocker,
-    ):
-        """New execution should have the same dataset links as the original."""
-        execution = reingest_execution_obj
-
-        # Create a dataset to link to the execution
-        dataset = CMIP6Dataset(
-            slug="test-dataset.tas.gn",
-            instance_id="CMIP6.test.tas",
-            variable_id="tas",
-            source_id="ACCESS-ESM1-5",
-            experiment_id="historical",
-            table_id="Amon",
-            grid_label="gn",
-            member_id="r1i1p1f1",
-            variant_label="r1i1p1f1",
-            version="v20200101",
-            activity_id="CMIP",
-            institution_id="CSIRO",
-        )
-        reingest_db.session.add(dataset)
-        reingest_db.session.flush()
-
-        reingest_db.session.execute(
-            execution_datasets.insert().values(
-                execution_id=execution.id,
-                dataset_id=dataset.id,
+            db_seeded.session.add(
+                Execution(
+                    execution_group_id=eg.id,
+                    successful=False,
+                    output_fragment="oldest-fail",
+                    dataset_hash="h1",
+                )
             )
-        )
-        reingest_db.session.commit()
+            db_seeded.session.flush()
 
-        original_dataset_ids = sorted(d.id for d in execution.datasets)
-        assert len(original_dataset_ids) >= 1
+            db_seeded.session.add(
+                Execution(
+                    execution_group_id=eg.id,
+                    successful=True,
+                    output_fragment="newer-success",
+                    dataset_hash="h1",
+                )
+            )
 
-        mock_result = mock_result_factory(
-            scratch_dir_with_results, output_bundle_filename=None, series_filename=None
-        )
-        _patch_build_result(mocker, mock_provider_registry, mock_result)
+        results = get_executions_for_reingest(db_seeded, execution_group_ids=[eg.id], include_failed=False)
+        assert len(results) == 0, "Should skip group when oldest execution is unsuccessful"
 
-        ok = reingest_execution(
-            config=config,
-            database=reingest_db,
-            execution=execution,
-            provider_registry=mock_provider_registry,
-        )
-        reingest_db.session.commit()
-        assert ok is True
+    def test_includes_group_when_oldest_unsuccessful_and_include_failed(self, db_seeded):
+        """When include_failed=True, include groups whose oldest execution failed."""
+        with db_seeded.session.begin():
+            diag = db_seeded.session.query(DiagnosticModel).first()
+            eg = ExecutionGroup(key="oldest-failed-incl", diagnostic_id=diag.id, selectors={})
+            db_seeded.session.add(eg)
+            db_seeded.session.flush()
 
-        new_execution = reingest_db.session.query(Execution).filter(Execution.id != execution.id).one()
-        new_dataset_ids = sorted(d.id for d in new_execution.datasets)
-        assert original_dataset_ids == new_dataset_ids, (
-            f"Dataset links should be copied: original={original_dataset_ids}, new={new_dataset_ids}"
-        )
+            db_seeded.session.add(
+                Execution(
+                    execution_group_id=eg.id,
+                    successful=False,
+                    output_fragment="oldest-fail-incl",
+                    dataset_hash="h1",
+                )
+            )
 
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_reingest_with_no_datasets(
-        self,
-        config,
-        reingest_db,
-        reingest_execution_obj,
-        mock_provider_registry,
-        scratch_dir_with_results,
-        mock_result_factory,
-        mocker,
-    ):
-        """Reingest should succeed even when original execution has no dataset links."""
-        assert len(reingest_execution_obj.datasets) == 0
-
-        mock_result = mock_result_factory(
-            scratch_dir_with_results, output_bundle_filename=None, series_filename=None
-        )
-        _patch_build_result(mocker, mock_provider_registry, mock_result)
-
-        ok = reingest_execution(
-            config=config,
-            database=reingest_db,
-            execution=reingest_execution_obj,
-            provider_registry=mock_provider_registry,
-        )
-        reingest_db.session.commit()
-        assert ok is True
-
-        new_execution = (
-            reingest_db.session.query(Execution).filter(Execution.id != reingest_execution_obj.id).one()
-        )
-        assert len(new_execution.datasets) == 0
-
-
-class TestReingestExecutionState:
-    """Verify the state of the new execution record after reingest."""
-
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_new_execution_marked_successful_with_correct_path(
-        self,
-        config,
-        reingest_db,
-        reingest_execution_obj,
-        mock_provider_registry,
-        scratch_dir_with_results,
-        mock_result_factory,
-        mocker,
-    ):
-        """New execution should be marked successful with the correct metric bundle path."""
-        mock_result = mock_result_factory(
-            scratch_dir_with_results, output_bundle_filename=None, series_filename=None
-        )
-        _patch_build_result(mocker, mock_provider_registry, mock_result)
-
-        ok = reingest_execution(
-            config=config,
-            database=reingest_db,
-            execution=reingest_execution_obj,
-            provider_registry=mock_provider_registry,
-        )
-        reingest_db.session.commit()
-        assert ok is True
-
-        new_execution = (
-            reingest_db.session.query(Execution).filter(Execution.id != reingest_execution_obj.id).one()
-        )
-        assert new_execution.successful is True
-        assert new_execution.path is not None
-        assert "diagnostic.json" in new_execution.path
-
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_new_execution_belongs_to_same_group(
-        self,
-        config,
-        reingest_db,
-        reingest_execution_obj,
-        mock_provider_registry,
-        scratch_dir_with_results,
-        mock_result_factory,
-        mocker,
-    ):
-        """New execution should belong to the same execution group as the original."""
-        mock_result = mock_result_factory(
-            scratch_dir_with_results, output_bundle_filename=None, series_filename=None
-        )
-        _patch_build_result(mocker, mock_provider_registry, mock_result)
-
-        ok = reingest_execution(
-            config=config,
-            database=reingest_db,
-            execution=reingest_execution_obj,
-            provider_registry=mock_provider_registry,
-        )
-        reingest_db.session.commit()
-        assert ok is True
-
-        new_execution = (
-            reingest_db.session.query(Execution).filter(Execution.id != reingest_execution_obj.id).one()
-        )
-        assert new_execution.execution_group_id == reingest_execution_obj.execution_group_id
-        assert new_execution.dataset_hash == reingest_execution_obj.dataset_hash
-
-
-class TestReingestFailureCleanup:
-    """Verify that failed reingest cleans up the results directory."""
-
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_results_dir_created_even_on_ingestion_error(
-        self,
-        config,
-        reingest_db,
-        reingest_execution_obj,
-        mock_provider_registry,
-        scratch_dir_with_results,
-        mock_result_factory,
-        mocker,
-    ):
-        """handle_execution_result logs ingestion errors; results dir is still created."""
-        mock_result = mock_result_factory(
-            scratch_dir_with_results, output_bundle_filename=None, series_filename=None
-        )
-        _patch_build_result(mocker, mock_provider_registry, mock_result)
-
-        # Corrupt the metric bundle — ingestion will log an error but reingest still succeeds
-        (scratch_dir_with_results / "diagnostic.json").write_text("not valid json")
-
-        ok = reingest_execution(
-            config=config,
-            database=reingest_db,
-            execution=reingest_execution_obj,
-            provider_registry=mock_provider_registry,
-        )
-        reingest_db.session.commit()
-        assert ok is True
-
-        new_execution = (
-            reingest_db.session.query(Execution).filter(Execution.id != reingest_execution_obj.id).one()
-        )
-        results_dir = config.paths.results / new_execution.output_fragment
-        assert results_dir.exists(), "Results directory should exist even when ingestion had errors"
-
-
-# --- ingest_execution_result standalone tests ---
-
-
-class TestIngestExecutionResultStandalone:
-    """Test ingest_execution_result with the simplified signature."""
-
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_ingest_with_all_outputs(
-        self, config, reingest_db, reingest_execution_obj, scratch_dir_with_data, mock_result_factory
-    ):
-        """Should ingest scalars, series, and register outputs in one call."""
-        mock_result = mock_result_factory(scratch_dir_with_data)
-        cv = CV.load_from_file(config.paths.dimensions_cv)
-
-        ingest_execution_result(
-            reingest_db,
-            reingest_execution_obj,
-            mock_result,
-            cv,
-            output_base_path=scratch_dir_with_data,
-        )
-        reingest_db.session.commit()
-
-        execution_id = reingest_execution_obj.id
-
-        scalars = reingest_db.session.query(ScalarMetricValue).filter_by(execution_id=execution_id).all()
-        assert len(scalars) >= 1, "Should have ingested scalar values"
-        assert scalars[0].value == 42.0
-
-        series = reingest_db.session.query(SeriesMetricValue).filter_by(execution_id=execution_id).all()
-        assert len(series) >= 1, "Should have ingested series values"
-
-        outputs = reingest_db.session.query(ExecutionOutput).filter_by(execution_id=execution_id).all()
-        assert len(outputs) >= 1, "Should have registered outputs"
-        assert any(o.short_name == "test_plot" for o in outputs)
-
-    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
-    def test_ingest_without_optional_outputs(
-        self, config, reingest_db, reingest_execution_obj, scratch_dir_with_data, mock_result_factory
-    ):
-        """Should work with no output_bundle and no series."""
-        mock_result = mock_result_factory(
-            scratch_dir_with_data, output_bundle_filename=None, series_filename=None
-        )
-        cv = CV.load_from_file(config.paths.dimensions_cv)
-
-        ingest_execution_result(
-            reingest_db,
-            reingest_execution_obj,
-            mock_result,
-            cv,
-            output_base_path=scratch_dir_with_data,
-        )
-        reingest_db.session.commit()
-
-        execution_id = reingest_execution_obj.id
-
-        scalars = reingest_db.session.query(ScalarMetricValue).filter_by(execution_id=execution_id).all()
-        assert len(scalars) >= 1, "Should still ingest scalar values"
-
-        series = reingest_db.session.query(SeriesMetricValue).filter_by(execution_id=execution_id).all()
-        assert len(series) == 0, "Should have no series values"
-
-        outputs = reingest_db.session.query(ExecutionOutput).filter_by(execution_id=execution_id).all()
-        assert len(outputs) == 0, "Should have no registered outputs"
+        results = get_executions_for_reingest(db_seeded, execution_group_ids=[eg.id], include_failed=True)
+        assert len(results) == 1, "Should include group when include_failed=True"

--- a/packages/climate-ref/tests/unit/executor/test_reingest.py
+++ b/packages/climate-ref/tests/unit/executor/test_reingest.py
@@ -117,7 +117,7 @@ def scratch_dir_with_results(config, reingest_execution_obj):
     CMECMetric(**CMECMetric.create_template()).dump_to_json(scratch_dir / "diagnostic.json")
     CMECOutput(**CMECOutput.create_template()).dump_to_json(scratch_dir / "output.json")
     TSeries.dump_to_json(scratch_dir / "series.json", SAMPLE_SERIES)
-    (scratch_dir / "execution.log").write_text("Execution log from original run\n")
+    (scratch_dir / "out.log").write_text("Execution log from original run\n")
 
     return scratch_dir
 
@@ -156,6 +156,7 @@ def scratch_dir_with_data(config, reingest_execution_obj):
     )
 
     TSeries.dump_to_json(scratch_dir / "series.json", SAMPLE_SERIES)
+    (scratch_dir / "out.log").write_text("Execution log from original run\n")
 
     return scratch_dir
 

--- a/packages/climate-ref/tests/unit/executor/test_result_handling.py
+++ b/packages/climate-ref/tests/unit/executor/test_result_handling.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 import shutil
 
@@ -5,13 +6,28 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from climate_ref.executor.result_handling import _copy_file_to_results, handle_execution_result
+from climate_ref.executor.result_handling import (
+    _copy_file_to_results,
+    handle_execution_result,
+    ingest_execution_result,
+    ingest_scalar_values,
+    ingest_series_values,
+    register_execution_outputs,
+)
 from climate_ref.models import ScalarMetricValue, SeriesMetricValue
-from climate_ref.models.execution import Execution, ExecutionOutput, ResultOutputType
+from climate_ref.models.diagnostic import Diagnostic as DiagnosticModel
+from climate_ref.models.execution import (
+    Execution,
+    ExecutionGroup,
+    ExecutionOutput,
+    ResultOutputType,
+)
 from climate_ref.models.metric_value import MetricValueType
+from climate_ref.models.provider import Provider as ProviderModel
 from climate_ref_core.diagnostics import ExecutionResult
 from climate_ref_core.logging import EXECUTION_LOG_FILENAME
 from climate_ref_core.metric_values import SeriesMetricValue as TSeries
+from climate_ref_core.pycmec.controlled_vocabulary import CV
 from climate_ref_core.pycmec.metric import CMECMetric
 from climate_ref_core.pycmec.output import CMECOutput
 
@@ -294,3 +310,246 @@ def test_copy_file_to_results_file_not_found(mocker):
         FileNotFoundError, match=f"Could not find {filename} in {scratch_directory / fragment}"
     ):
         _copy_file_to_results(scratch_directory, results_directory, fragment, filename)
+
+
+SAMPLE_SERIES = [
+    TSeries(
+        dimensions={"source_id": "test-model"},
+        values=[1.0, 2.0, 3.0],
+        index=[0, 1, 2],
+        index_name="time",
+        attributes={"units": "K"},
+    )
+]
+
+
+@pytest.fixture
+def _ingestion_db(db, config):
+    """Set up a database with an execution group and execution for ingestion tests."""
+    with db.session.begin():
+        provider_model = ProviderModel(name="mock_provider", slug="mock_provider", version="v0.1.0")
+        db.session.add(provider_model)
+        db.session.flush()
+
+        diag_model = DiagnosticModel(
+            name="mock",
+            slug="mock",
+            provider_id=provider_model.id,
+        )
+        db.session.add(diag_model)
+        db.session.flush()
+
+        eg = ExecutionGroup(
+            key="test-key",
+            diagnostic_id=diag_model.id,
+            selectors={"cmip6": [["source_id", "ACCESS-ESM1-5"], ["variable_id", "tas"]]},
+            dirty=False,
+        )
+        db.session.add(eg)
+        db.session.flush()
+
+        execution = Execution(
+            execution_group_id=eg.id,
+            successful=True,
+            output_fragment="mock_provider/mock/abc123",
+            dataset_hash="hash1",
+        )
+        db.session.add(execution)
+        db.session.flush()
+
+    return db
+
+
+@pytest.fixture
+def ingestion_execution(_ingestion_db):
+    """Get the execution object from the ingestion DB fixture."""
+    return _ingestion_db.session.query(Execution).one()
+
+
+@pytest.fixture
+def scratch_dir_with_data(config, ingestion_execution):
+    """Create a scratch directory with CMEC files containing actual metric/output data."""
+    scratch_dir = config.paths.scratch / ingestion_execution.output_fragment
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+
+    (scratch_dir / "diagnostic.json").write_text(
+        json.dumps(
+            {
+                "DIMENSIONS": {
+                    "json_structure": ["source_id", "metric"],
+                    "source_id": {"test-model": {}},
+                    "metric": {"rmse": {}},
+                },
+                "RESULTS": {"test-model": {"rmse": 42.0}},
+            }
+        )
+    )
+
+    (scratch_dir / "plot.png").write_bytes(b"fake png")
+    (scratch_dir / "output.json").write_text(
+        json.dumps(
+            {
+                "index": "index.html",
+                "provenance": {"environment": {}, "modeldata": [], "obsdata": {}, "log": "cmec_output.log"},
+                "data": {},
+                "plots": {"test_plot": {"filename": "plot.png", "long_name": "Test Plot", "description": ""}},
+                "html": {},
+                "metrics": None,
+                "diagnostics": {},
+            }
+        )
+    )
+
+    TSeries.dump_to_json(scratch_dir / "series.json", SAMPLE_SERIES)
+    (scratch_dir / "out.log").write_text("Execution log from original run\n")
+
+    return scratch_dir
+
+
+@pytest.fixture
+def mock_result_factory(mocker):
+    """Factory to create mock ExecutionResult objects with sensible defaults."""
+
+    def _create(
+        output_dir,
+        *,
+        output_bundle_filename=pathlib.Path("output.json"),
+        series_filename=pathlib.Path("series.json"),
+    ):
+        mock_result = mocker.Mock(spec=ExecutionResult)
+        mock_result.successful = True
+        mock_result.metric_bundle_filename = pathlib.Path("diagnostic.json")
+        mock_result.output_bundle_filename = output_bundle_filename
+        mock_result.series_filename = series_filename
+        mock_result.retryable = False
+        mock_result.to_output_path = lambda f: output_dir / f if f else output_dir
+        mock_result.as_relative_path = pathlib.Path
+        return mock_result
+
+    return _create
+
+
+class TestRegisterExecutionOutputs:
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_registers_outputs_in_db(self, config, _ingestion_db, ingestion_execution, scratch_dir_with_data):
+        """Should register output entries from the bundle into the database."""
+        bundle_path = scratch_dir_with_data / "output.json"
+        cmec_output_bundle = CMECOutput.load_from_json(bundle_path)
+
+        register_execution_outputs(
+            _ingestion_db,
+            ingestion_execution,
+            cmec_output_bundle.plots,
+            output_type=ResultOutputType.Plot,
+            base_path=scratch_dir_with_data,
+        )
+        _ingestion_db.session.commit()
+
+        outputs = (
+            _ingestion_db.session.query(ExecutionOutput).filter_by(execution_id=ingestion_execution.id).all()
+        )
+        assert len(outputs) >= 1
+        assert any(o.short_name == "test_plot" for o in outputs)
+
+
+class TestIngestScalarValues:
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_ingest_scalar_values(
+        self, config, _ingestion_db, ingestion_execution, scratch_dir_with_data, mock_result_factory
+    ):
+        """Should ingest scalar metric values from a real CMEC bundle."""
+        mock_result = mock_result_factory(scratch_dir_with_data)
+        cv = CV.load_from_file(config.paths.dimensions_cv)
+
+        ingest_scalar_values(database=_ingestion_db, result=mock_result, execution=ingestion_execution, cv=cv)
+        _ingestion_db.session.commit()
+
+        scalars = (
+            _ingestion_db.session.query(ScalarMetricValue)
+            .filter_by(execution_id=ingestion_execution.id)
+            .all()
+        )
+        assert len(scalars) >= 1
+        assert scalars[0].value == 42.0
+
+
+class TestIngestSeriesValues:
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_ingest_series_values(
+        self, config, _ingestion_db, ingestion_execution, scratch_dir_with_data, mock_result_factory
+    ):
+        """Should ingest series metric values from a real series file."""
+        mock_result = mock_result_factory(scratch_dir_with_data)
+        cv = CV.load_from_file(config.paths.dimensions_cv)
+
+        ingest_series_values(database=_ingestion_db, result=mock_result, execution=ingestion_execution, cv=cv)
+        _ingestion_db.session.commit()
+
+        series = (
+            _ingestion_db.session.query(SeriesMetricValue)
+            .filter_by(execution_id=ingestion_execution.id)
+            .all()
+        )
+        assert len(series) >= 1
+
+
+class TestIngestExecutionResult:
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_ingest_with_all_outputs(
+        self, config, _ingestion_db, ingestion_execution, scratch_dir_with_data, mock_result_factory
+    ):
+        """Should ingest scalars, series, and register outputs in one call."""
+        mock_result = mock_result_factory(scratch_dir_with_data)
+        cv = CV.load_from_file(config.paths.dimensions_cv)
+
+        ingest_execution_result(
+            _ingestion_db,
+            ingestion_execution,
+            mock_result,
+            cv,
+            output_base_path=scratch_dir_with_data,
+        )
+        _ingestion_db.session.commit()
+
+        execution_id = ingestion_execution.id
+
+        scalars = _ingestion_db.session.query(ScalarMetricValue).filter_by(execution_id=execution_id).all()
+        assert len(scalars) >= 1, "Should have ingested scalar values"
+        assert scalars[0].value == 42.0
+
+        series = _ingestion_db.session.query(SeriesMetricValue).filter_by(execution_id=execution_id).all()
+        assert len(series) >= 1, "Should have ingested series values"
+
+        outputs = _ingestion_db.session.query(ExecutionOutput).filter_by(execution_id=execution_id).all()
+        assert len(outputs) >= 1, "Should have registered outputs"
+        assert any(o.short_name == "test_plot" for o in outputs)
+
+    @pytest.mark.filterwarnings("ignore:Unknown dimension values.*:UserWarning")
+    def test_ingest_without_optional_outputs(
+        self, config, _ingestion_db, ingestion_execution, scratch_dir_with_data, mock_result_factory
+    ):
+        """Should work with no output_bundle and no series."""
+        mock_result = mock_result_factory(
+            scratch_dir_with_data, output_bundle_filename=None, series_filename=None
+        )
+        cv = CV.load_from_file(config.paths.dimensions_cv)
+
+        ingest_execution_result(
+            _ingestion_db,
+            ingestion_execution,
+            mock_result,
+            cv,
+            output_base_path=scratch_dir_with_data,
+        )
+        _ingestion_db.session.commit()
+
+        execution_id = ingestion_execution.id
+
+        scalars = _ingestion_db.session.query(ScalarMetricValue).filter_by(execution_id=execution_id).all()
+        assert len(scalars) >= 1, "Should still ingest scalar values"
+
+        series = _ingestion_db.session.query(SeriesMetricValue).filter_by(execution_id=execution_id).all()
+        assert len(series) == 0, "Should have no series values"
+
+        outputs = _ingestion_db.session.query(ExecutionOutput).filter_by(execution_id=execution_id).all()
+        assert len(outputs) == 0, "Should have no registered outputs"


### PR DESCRIPTION
## Description

Reingest was using `shutil.copytree` to copy the entire scratch directory to results, which included ESMValTool working artifacts like `climate_data/` and `executions/` directories. The initial execution path in `handle_execution_result` selectively copies only output files (metric bundle, output bundle, plots, series, log).

Refactored `reingest_execution` to:
1. Copy scratch to a **new scratch location** (matching the new fragment) instead of directly to results
2. Ensure a placeholder execution log exists for `handle_execution_result`
3. Delegate to `handle_execution_result` for selective file copying and DB ingestion
4. Save/restore the `dirty` flag since `handle_execution_result` resets it

This ensures reingest produces the same results directory structure as initial execution -- no `climate_data/` or `executions/` working directory artifacts.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`